### PR TITLE
Introduce global variable indicating if tests are running

### DIFF
--- a/packages/baseclient/config/webpack.common.config.js
+++ b/packages/baseclient/config/webpack.common.config.js
@@ -125,7 +125,8 @@ const commonWebpackConfig = {
     ]),
     new webpack.DefinePlugin({
       PROJECT_MAIN_PATH: JSON.stringify(PROJECT_MAIN_PATH),
-      PROJECT_MAIN_CLASS: new RegExp('^./' + PROJECT_MAIN_CLASS + '\\.(jsx|js|ts|tsx)$')
+      PROJECT_MAIN_CLASS: new RegExp('^./' + PROJECT_MAIN_CLASS + '\\.(jsx|js|ts|tsx)$'),
+      ___TEST___: JSON.stringify(TARGET.indexOf('test') > -1)
     })
   ],
 

--- a/packages/baseclient/src/Main.tsx
+++ b/packages/baseclient/src/Main.tsx
@@ -42,7 +42,7 @@ export class Main extends React.Component<MainProps, MainState> {
     // require.context may not be available in test setup. Use
     // default ProjectMain instead
     // @ts-ignore
-    if (!require.context) {
+    if (___TEST___){
       this.main = ProjectMain;
       return;
     }


### PR DESCRIPTION
…using `npm_lifecycle_event`.

Depends on https://github.com/terrestris/react-geo-baseclient/pull/351