### PR TITLE
Overviewmap with choosers for basemap and topics / layersets

### DIFF
--- a/packages/baseclient-components/index.d.ts
+++ b/packages/baseclient-components/index.d.ts
@@ -1,2 +1,3 @@
 declare module '*';
 declare module 'baseclient-components';
+declare module '@brainhubeu/react-carousel';

--- a/packages/baseclient-components/package-lock.json
+++ b/packages/baseclient-components/package-lock.json
@@ -887,6 +887,11 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@brainhubeu/react-carousel": {
+			"version": "1.10.17",
+			"resolved": "https://registry.npmjs.org/@brainhubeu/react-carousel/-/react-carousel-1.10.17.tgz",
+			"integrity": "sha512-MkkyhU6DTAZRcOmAdyiq2phCqE2C6ABYvMuGzR6+Pd6mrl2+p/IXXWmefIYk5Idvr+pyiTP0Jvh1S4+qojpoSQ=="
+		},
 		"@cnakazawa/watch": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -3071,8 +3076,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3093,14 +3097,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3115,20 +3117,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3245,8 +3244,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3258,7 +3256,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3273,7 +3270,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3281,14 +3277,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -3307,7 +3301,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3388,8 +3381,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3401,7 +3393,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3487,8 +3478,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3524,7 +3514,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3544,7 +3533,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3588,14 +3576,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/packages/baseclient-components/package.json
+++ b/packages/baseclient-components/package.json
@@ -19,7 +19,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@terrestris/mapfish-print-manager": "^5.0.0"
+    "@terrestris/mapfish-print-manager": "^5.0.0",
+    "@brainhubeu/react-carousel": "^1.10.17"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.0",

--- a/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.less
+++ b/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.less
@@ -1,30 +1,13 @@
 .carousel-wrapper {
-  position: absolute;
-  bottom: 5px;
-  left: 0px;
-  width: 100%;
-  height: 165px;
-  background-color: rgba(255,255,255,0.5);
-}
+  user-select: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -webkit-touch-callout: none;
 
-.carousel-slide {
-  background-color: rgba(228,226,226,0.5);
-  text-align: center;
-  font-size: 1.2em;
-  border: 1px solid #b7b6b6;
-  border-radius: 4px;
-  padding: 5px;
-
-  > img {
-    margin: 0 auto;
+  .slick-slider, .slick-list {
+    height: 100%;
+    width: 100%;
   }
-}
-
-.carousel-slide.selected {
-  border: 2px solid gray;
-}
-
-.ant-carousel {
-  width: 100%;
-  height: 100%;
 }

--- a/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.less
+++ b/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.less
@@ -5,9 +5,4 @@
   -webkit-user-select: none;
   -khtml-user-select: none;
   -webkit-touch-callout: none;
-
-  .slick-slider, .slick-list {
-    height: 100%;
-    width: 100%;
-  }
 }

--- a/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.spec.tsx
+++ b/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.spec.tsx
@@ -1,0 +1,33 @@
+/*eslint-env jest*/
+import TestUtils from '../../../spec/TestUtils';
+
+import LayerCarousel from './LayerCarousel';
+
+describe('<LayerCarousel />', () => {
+  let map;
+  let wrapper: any;
+
+  beforeEach(() => {
+    map = TestUtils.createMap({});
+    wrapper = TestUtils.shallowComponent(LayerCarousel, {
+      map: map,
+      t: (t: string) => t
+    }, {});
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    TestUtils.unmountMapDiv();
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(LayerCarousel).not.toBe(undefined);
+    });
+
+    it('can be rendered', () => {
+      expect(wrapper).not.toBe(undefined);
+    });
+  });
+
+});

--- a/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.tsx
+++ b/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.tsx
@@ -68,14 +68,27 @@ export default class LayerCarousel extends React.Component<LayerCarouselProps, L
     this.renderTrigger = this.renderTrigger.bind(this);
   }
 
+  /**
+   * @memberof LayerCarousel
+   */
   componentDidMount() {
     this.props.map.on('moveend', this.renderTrigger);
   }
 
+  /**
+   *
+   *
+   * @memberof LayerCarousel
+   */
   componentWillUnmount() {
     this.props.map.un('moveend', this.renderTrigger);
   }
 
+  /**
+   *
+   *
+   * @memberof LayerCarousel
+   */
   renderTrigger() {
     this.setState({
       renderTrigger: this.state.renderTrigger + 1
@@ -278,7 +291,7 @@ export default class LayerCarousel extends React.Component<LayerCarouselProps, L
           arrows={true}
           infinite={true}
           centered={true}
-          slidesPerPage={Math.round(window.innerWidth / this.getWidth() - 1) * 2}
+          slidesPerPage={Math.round(window.innerWidth / this.getWidth()) - 1}
           afterChange={(a: any) => console.log(a)}
           arrowLeft={<Icon type="left" />}
           arrowRight={<Icon type="right" />}

--- a/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.tsx
+++ b/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.tsx
@@ -292,7 +292,6 @@ export default class LayerCarousel extends React.Component<LayerCarouselProps, L
           infinite={true}
           centered={true}
           slidesPerPage={Math.round(window.innerWidth / this.getWidth()) - 1}
-          afterChange={(a: any) => console.log(a)}
           arrowLeft={<Icon type="left" />}
           arrowRight={<Icon type="right" />}
           addArrowClickHandler={true}

--- a/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.tsx
+++ b/packages/baseclient-components/src/component/LayerCarousel/LayerCarousel.tsx
@@ -216,7 +216,7 @@ export default class LayerCarousel extends React.Component<LayerCarouselProps, L
    * findLayer - Find a clicked/hovered layer.
    *
    * @param {Object} evt The mouseover/click event
-   * @return {OlLayer} The clicked/hovered layer object
+   * @return {OlLayer} layer The clicked/hovered layer object
    */
   findLayer (evt: any) {
     let targetElement = evt.target;

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.less
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.less
@@ -1,61 +1,30 @@
-.slick-slide {
+.BrainhubCarouselItem {
   text-align: center;
-  height: 100%;
-  width: 192px !important;
-  background: #4ba9ff;
+  border: 1px solid white;
+  border-radius: 4px;
+  background-color: white;
+
   overflow: hidden;
   margin: 0 3px;
   opacity: .85;
 
-  .layersetentry {
-    width: 192px;
-  }
-
   &:hover {
     opacity: 1;
-    border: 1px solid white;
+    background-color: rgba(white, 0.5)
   }
 
-  >div {
-    height: 100%;
+  > img {
+    flex: 1;
+    align-self: center;
+    margin: 5px 10px 10px 10px;
+    max-width: 95%;
+    box-sizing: content-box;
+    box-shadow: 0 0 10px 5px darken(#4ba9ff, 15%);
+    background: white;
+    cursor: pointer;
+  }
 
-    .layersetentry {
-      font-size: 1.1em;
-      color: white;
-      cursor: all-scroll;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-
-      >.title-div {
-        position: relative;
-        width: 100%;
-
-        >.loading-div {
-          position: absolute;
-          top: 0;
-          right: 0;
-        }
-      }
-
-      > img {
-        flex: 1;
-        align-self: center;
-        margin: 5px 10px 10px 10px;
-        max-width: 95%;
-        box-sizing: content-box;
-        box-shadow: 0 0 10px 5px darken(#4ba9ff, 15%);
-        background: white;
-        cursor: pointer;
-      }
-
-      button {
-        background: none;
-        border: none;
-        &:hover {
-          border: none;
-        }
-      }
-    }
+  .title-div {
+    background-color: lighten(#4ba9ff, 25%);
   }
 }

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.less
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.less
@@ -1,0 +1,61 @@
+.slick-slide {
+  text-align: center;
+  height: 100%;
+  width: 192px !important;
+  background: #4ba9ff;
+  overflow: hidden;
+  margin: 0 3px;
+  opacity: .85;
+
+  .layersetentry {
+    width: 192px;
+  }
+
+  &:hover {
+    opacity: 1;
+    border: 1px solid white;
+  }
+
+  >div {
+    height: 100%;
+
+    .layersetentry {
+      font-size: 1.1em;
+      color: white;
+      cursor: all-scroll;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+
+      >.title-div {
+        position: relative;
+        width: 100%;
+
+        >.loading-div {
+          position: absolute;
+          top: 0;
+          right: 0;
+        }
+      }
+
+      > img {
+        flex: 1;
+        align-self: center;
+        margin: 5px 10px 10px 10px;
+        max-width: 95%;
+        box-sizing: content-box;
+        box-shadow: 0 0 10px 5px darken(#4ba9ff, 15%);
+        background: white;
+        cursor: pointer;
+      }
+
+      button {
+        background: none;
+        border: none;
+        &:hover {
+          border: none;
+        }
+      }
+    }
+  }
+}

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.spec.tsx
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.spec.tsx
@@ -1,0 +1,33 @@
+/*eslint-env jest*/
+import TestUtils from '../../../spec/TestUtils';
+
+import LayerCarouselSlide from './LayerCarouselSlide';
+
+describe('<LayerCarouselSlide />', () => {
+  let map;
+  let wrapper: any;
+
+  beforeEach(() => {
+    map = TestUtils.createMap({});
+    wrapper = TestUtils.shallowComponent(LayerCarouselSlide, {
+      map: map,
+      t: (t: string) => t
+    }, {});
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    TestUtils.unmountMapDiv();
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(LayerCarouselSlide).not.toBe(undefined);
+    });
+
+    it('can be rendered', () => {
+      expect(wrapper).not.toBe(undefined);
+    });
+  });
+
+});

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
@@ -4,16 +4,16 @@ import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlLayerGroup from 'ol/layer/Group';
 
-import { SimpleButton } from '@terrestris/react-geo';
-
 import './LayerCarouselSlide.less';
+import { Spin } from 'antd';
 
 // default props
 export interface DefaultLayerCarouselSlideProps {
   layer: any;
   extent: number[];
-  mapSize: number;
   projection: String;
+  width: number;
+  ratio: number;
 }
 
 export interface LayerCarouselSlideProps extends Partial<DefaultLayerCarouselSlideProps> {
@@ -32,7 +32,15 @@ export interface LayerCarouselSlideState {
  * @class The Slide.
  * @extends React.Component
  */
-export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps, LayerCarouselSlideState> {
+export class LayerCarouselSlide extends React.PureComponent<LayerCarouselSlideProps, LayerCarouselSlideState> {
+
+  public static defaultProps: DefaultLayerCarouselSlideProps = {
+    layer: null,
+    extent: [],
+    projection: 'EPSG:3857',
+    width: 128,
+    ratio: 1
+  };
 
   /**
    *Creates an instance of Slide.
@@ -50,14 +58,16 @@ export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps,
     this.onLoad = this.onLoad.bind(this);
   }
 
-    /**
+  /**
    *
    * @param layer
    */
   getLayerPreview(layer: any) {
     const {
       extent,
-      projection
+      projection,
+      width,
+      ratio
     } = this.props;
 
     if (!extent) {
@@ -65,10 +75,10 @@ export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps,
     }
 
     if (!layer) {
-      return;
+      return  '404';
     }
 
-    // TODO: nicer image
+    // TODO: combine images if return custom image, currently placeholder
     if (layer instanceof OlLayerGroup) {
       return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKIAAACiCAIAAABNkIFMAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4wURDS8BEYLnrgAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAZGUlEQVR42u1d2VMb2blvqTetrV0CCdRiMcYyNovHniF2Uk6mJo4zU5VKZXnIX5M/KJWH1KRck8SOZzIw2GYxGANjQAtCEhJCe7da6lbrPnw3ffu2BGgYDBjO9+CyBEjnnN/59qV1rVYLQ3TZSY+OAMGMCMGMCMGMCMGMCMGMCMGMCMGMCMGMYEaEYEaEYEaEYEaEYEaEYEaEYEaEYEaEYEYwI0IwI0IwI0IwI0IwI0IwI0IwI0IwI0IwI5gRIZgRIZgRIZgRIZgRIZgRIZgRIZgRIZgRzIgQzIgQzIgQzIgQzIgQzIgQzIi6J6LL32v9l+Cl7r+ETvCHknpI6pkdINHNsprNZq1Wq1artVpNlmWKogwGA03TNE3jOK7X6xHqXQIsy3Kj0ZAkCcMwgiAoioLTO2eYW62WKIr5fH5nZycajWaz2Xq9rtfrGYZhGMZmszEM43A4TCaTyWQym80EQej1es3NPXYbrVZLp6LLirEkSZVKpVgschyHYZjZbLbb7VarlSCI973rY2CWZblUKq2trc3Ozi4vL6dSKY7j9Ho9RVEWi8VsNjMM4/P53G632+32er0Oh4NhGGXROp1OgVCv1zebTXgJ8OM4LssyhmF6vZ6mabPZbLFYjEYjjuOXD2xZliuVSjwej8fj2WwWwzCv18uyLMuyNpsNx/Fzg7nVatXr9Ww2u7a2NjMzs7KyUiqVJEkCqHAcx3GcJEmKoqxWK8MwLpfLZrO53W6DwYDjeLPZlGVZr9fr9XrYBtzoVqsF7wDerVaLJEmHw9HX1zc4OMiyrNPpJEnyMiHdarUajUaxWIzH4y9fvtzc3MQw7Nq1axiG2Ww2o9FoMBje636P4WZJksrlcjKZjMfjuVwOQNL8jk6n29/fx3EclA1JkgRBEAQBnAqrh38VIw6YW/lzkiStVmswGLxz5879+/dv3brldDrf9wU/Y5IkieO4bDa7ubn5+vVreDMUCnEcB6r6Qljaal2rQRpeNptNURRrtdrR+rWjttbpdARBpFIpnudtNpvP5zObzUajEdl0ZwQzQRAMwwQCgWAwWCwWi8WiJEkgjbu8BIeRoraVW1IoFHZ2dlKpVLlcPoMLftYHTRBms9nr9YKsBqHt9XrBbj1PmHU6HU3TXq83HA4Xi0Wz2RyLxXK5XKVS4XleFEUFUfTAjGPvNEVRdrudZVmQ1YoJZrfbKYo6Z0tbr9fbbLZwOGyxWK5du7a7uwueVSKRyOVyHMeJogjiWpZlBWy9Xq9wtiKl1TvpKLRtNlswGPT7/QzDnMEFP2PS6/VWqxXsao1DpXZB39c9O5YR1eERjuMqlUo6nX737l0ymcxms5VKZX9/P5fLlctlQRBarRa4zqCnG42G4jJRFGU0GimKAhv7qplg5xse0XUpb1sqEkWxVCrlcjme58vlcqFQiMVi2Ww2n88D14qiGIvFNjY2Dg4OlC253e7R0dGBgQGGYcAZuzoO1QcQ7FQWpKyJIAiDweB2uwGkZrMJqAuCUK/XKYpKJpNPnjyJRqPqnVAUNTIy8vjx44GBAXjzSoVHzh7akztUGm2qvFRQh9tK07TNZlN8ZeVPbDbb4ODg6OioRiBfhWDnhXaoToB6s9kEE0xtlCm2GMS/Lp/evegG4Pv4UFmWm80mRLA1MCPX6/LALIoiz/PNZlPN7hAAPwPnAdFZwCzLMnhfoihqwkA0TRsMBnTolwFmSZIKhUK5XG40GupEhclkslqtNE0jI+uDhxlyl4VCoVQqqYU2juM2mw0KEBDMlwFmjuOKxWKlUlHDTJKk3W53uVwo73RJYBYEgeM4qBpT7C+KohwOh8PhuHzB6iuqmyGaXa/X1XkLiFojif1hh0c0MEPaClMF9sCbOoPaNkRnBDPUPaFgyCXXzTqdrr28RKkIQ8BfnvBIewYChDY67ssDc7PZFARBXcwFiQ2TyXQG1TCIzkI3Q+4ZavbUITDIJR8b6VQXL7QXEp1ZmvKw2iYE8/+eTq1Wy2azuVyuVqspahjHcavVarfbj4iNQPVMrVbjOA7KE5SKA1mWoZABmjzea7hUkqRarQYOIRQ7WK3WSyCEThnmarW6t7enKdwnCMJutzudzo69BRBR2d/fTyQS6XQ6nU6Xy+VqtSpJksLBFEWZTKb+/v6BgYHh4WGn03nqYRZZlsvlciqVikQi2Wy2XC4bDAaPxzMwMDA4OMgwzI/MrZ1LbdD7glkQhGKxWK1WlUinEhux2+3tjAg9Wuvr6wsLC99//30kEsnlctDCo6SrQewbjUaPx3Pjxo1PPvnkwYMHfX19J2YySIeDmAHwRFHMZDKLi4tzc3MbGxu7u7uCIJAkGQgEpqamHj58ODExodTDnOBYZFmu1+tKWRxN02dT6fe+dHPjv6S+vARBWCwWq9XaXhtULBbn5uaePHmytLQUi8Ugr6WuR/g/W1Gvj8Vi29vb0Wi0UCg8fvyYZdkfKsAhSQrMimEYwzBer5cgiEQi8eTJk6dPn66uru7v7wuCAP7C9vZ2KpWSZdlqtY6NjdE0fQKMoUJS86U2m+0syxpPGWYNF6q5uR0SjuNWVlb+9re/zczMxGIxJQyuLh9T/t9sNiVJSqfTtVpNkiSapj///HO/39+99JZlOZ/Pr66urqyspNPpVqvl9/vD4bDdbn/69Onf//739fV1pRcQ/qRSqWxubi4sLNy8eTMYDLrd7h8KTLPZzOfza2tra2tryWQSw7BAIBAOh8PhsNvtPrMI/yl/DY7j7fVA0EWnYeVms5lOp7/77ruFhYVIJKI22Y7gjGazWSwWV1dXe3p6hoeHocG6y6PnOO7169d/+ctf5ufnM5kMhmFerxdqwufn51dXV8vlsjqrpnB/PB7f2dnhOM7lcv0gmMEm3dnZmZmZmZmZicfjGIaxLFsoFKBt2GKxdNP8rZ4ToaEuHZDTN2TUvKj5kfplrVbb3t5+8+ZNPB6HOv7D1q3ZJyC9sbGxvb0dDoetVms3R99oNDY2Nv7xj388f/48FotBZxA0Elit1r29vVKp1LExTJZlnudLpVI3F7GjTRqJRJaWlpaXl/P5PIZhxWLRZDJdu3atv7/fbDYfsXhZlgVBqFar1WoV9Ig69ASOgMlk6qbq+ZRhBobTcLP6TeUdjuOSyWQsFqtWq5qUpclkUtYNZWUcx6k/QZKkfD6fSqWq1eqxRw8cGYvFnj59+vXXXycSCcV0aDQamUymUChoINQEZSVJEkXxBN17rVaL5/lkMplIJEqlElRNlUqlRCKRTCZ5nj9i8Y1GI5/Pb21txWKx3d1dpRpHGQECTVmBQGBwcDAYDB7dw3DKljYEtNs7Y5vNpvrsYP+ZTAZaLNU2uc/nGx0dHRoagqylIAhra2urq6sHBweKRIUaFY7jNLZeO8Acxx0cHGxsbHz33XfPnz/f3NyEDKnaPpIkqb0BTFmt0nJwsjOp1+tKJ6lyaeCder1+2LKr1WosFpubm4Oe92w2KwiCKIqwKpgMAJUa/f39k5OTx3YknT43d/QvleY5NU6CIGiqD4xG48jIyB/+8IfJyUmKojAMEwTh66+/Bi9LDUa7Fmjnhv39/Y2NjaWlpfn5+fX19d3d3UqlovkrjUaAEwTVoFY9J24EgbAP6Ajl3oiiqHSXtXukqVTqzZs3s7Ozc3NzkUgkn89DJ2K7Pk4mk7u7uzzPOxyOo5vCTxPmI8yB9h9BvEmDHE3TQ0NDk5OTY2NjYIUWi8Xl5WWNRQrlwDD6ouPXCYIQj8efP3++sLCwuLiYSqWKxSKcbDv3q80CgiBIklTy5WoT8sRWcXtnQsdlQAjh7du3//nPf168ePH27dtMJsPzfMdfhtWCXxOPx5PJ5NFN4adv0B/Gze27gg0o8CuKGQoQoMMql8ttbW1By516t0aj0Wq1Go3Gjpp4c3Pzq6++gnkp+/v7EDrt6KdpDg5iF+rWbZ1OZzAYjEZj+3d1Hx7vCLNGvJVKpbm5uS+//PLFixfRaBQqoE8rb3vKMB8h2dp/pGCvPlO1dhEE4fvvvwcbVS3bCYJwOBw9PT1qSxWEYS6Xe/PmzdOnT0FQa+4HXCnN+apXCOFY9XdBh7fH4zlZsSKA2p6G0fBotVpdXFz861//Ojs7G4vFwPVoj48q/wJBUzjLsoFA4Oim8NPXzeoMD3Z4W03HI5NlWTFrQRy9fPkyEomoPS5g5f7+fnBI4K5AyUoymZydnf33v//9+vVrYAh1ogzDMJIkYcRRR0aB5i6N1oR5DYFAwGKxnCCsrTT3trO4cgL1ej0SifzrX/+an58HjDWaGAwumqaNRiM0oWlMsHA47PV6j4gJnj7M3VxeNdLKhsHL2traWllZAcvlxYsX33zzzd7entogIggC5mQMDAwomU0Q77Ozs19++eXCwkIqlarX60o9mpLwttlser0ejHaN8Q+ChCAItZ+j1+stFkswGAwEAicri+gY2VCfD6z822+/ffnyZTQaVWMMAFMUZbPZent7Q6EQ2FngU2kcKtja2QntYy+vwjqwLLWQ5Hl+cXGxXq+zLFuv17e2tra3tzmOU4NhMpnATOvp6VHGjQmCkEwmNzY2VldXd3d3FY4E8Ewmk8/nC4VCfX19mUxmfn4exkJo1glAqq+UTqeDgSEul+sEXZygR9QXDmurl6rValtbW6urq+/eveM4TjkKiH44nU6WZW/dujU2NgZxWcU5Ps/wSEeB3NnEJwiDwUCSpMaLhRA/TM5SPC5F8BIE0dvbe+/evZs3b5pMJuXTRFGsVCqZTObg4ECDscPhuH79+q1btz755BOj0fjs2bOlpaWORiJBEJpIDkmSHo8HxqGcQDE3m81KpVIoFBqNBvb/Jy0pwxo4jkskEhsbG/l8XrlhUIgxMDAwMTHxs5/97Pbt28Fg0G63t2vf8wl2KjtR28/tho9OpzObzW63G9JWyhWGMYAcx/E8j7VNoNLr9Q6HY2pq6uOPP+7p6dHIKJBjMM0DFkCSpMvlGh8fn56efvToEcuyu7u7s7OzHQ8FtB3Y/8oH0jTtdrt9Pt8J7C+QMdlsFgadqrcPlXEQ/4do4MHBgWIuwPeyLPvw4cPf/e53o6Ojaia+EJZ2s9kEGaWxvDQiBWBmWXZgYCAajWoqQTvqMxzHGYYJh8P3798fHx83m83qn1IU5fF4WJYNhUKNRoPjOJIk3W737du3Hzx48OjRo1AoRBBENpuFS9BuD4Lyrlarmo91OBx2ux2KWNRTFbqBGQYkZrNZdXMojuPgDUL8B8J56rgNwBwKhT777LM7d+6cSg/DacIM00fBT9UkMDThBZ1OZ7FYrl+/fvv27Wg0+u7dO40trRH4MIVubGzsF7/4xc9//nO3261mZTgXn883NTXVaDRYli0Wi0ajkWXZycnJ6elpMKBAJAJg7V9EkqTJZAIpok6hMgwDgeh6vS6KIkmSBoPBarUey16Q94xEIsViUZ2cJQjC6XR6vV5IT0mSpJhdiswD3eT3+09rludpwszzfCwWS6fTgiCoNQcM39a0XOA43t/f//jx42KxKMtyPB4HE1fj4+I4TlEUTCG6f//+b37zm8HBQeADjci12+1jY2MOh2N8fJzneaPR2NvbC3OJlBsG5l47zLBIq9UKSSS1uZDL5RYXF9++fVupVFqtls1mCwQCoVDI7/cfLckhBQn5FQVFZToYy7KKQFK7/uogzwlyYu8dZlmWDw4Otra20um0puvCaDS6XC5N0g1Odmxs7E9/+pPdbl9ZWdne3oaMm6IpKYqCWovR0dFwOPzgwYNQKNSxhAM4D5Q9y7JQJWg2mzXzEWRZBqe8XWhDTE0x/hWpu7i4uLOzI0kSz/NwmW7cuPHxxx9PT0/39/e3Xzh1bmZ/f393d7dWq6kvt8vlunHjBsuycEvAG1aLOlDq0Wg0EoncunWry0zrGcEsiuLOzk4sFiuVSmqOpGm6p6fH4/GoDWO16L59+7bH43nz5k0ikchms7VaTRRFYGIoLQoEAn6/PxQKud3uI5xXkIeg+Q6LsMLg8vZ0EwhSu92umX4ESfFoNKrIAJqm9/b2cBwPBALQ49kRAygoyGQyUKqgrn70er3Dw8NerxdMMJAiauEMeZ1YLPbs2bPh4eGJiYkfL7pPB2a4vJVKpVqtqhUzyCgA6bAUutFoDIVCHo+H4ziO4xQLDpCGWdNms7nLrR5tH0FFoibED3LF7/e73W6apjVpck3dkiiKyWQSShNrtdphE88BKkiBqCUHiByn06nUKxqNRofDAZ+jLKzZbOZyuVevXoETFQ6HNSbnOZtgmimNNE339/dPTEwEAoEjwgtwG8xms1rUa/yxU/ECyuVyexYEzP7BwUGn0wmPJAA3tz3ofdg7HW8bDLQzmUwQXlXuk9vtdjgccBogz1iW9fv96+vr6vS5KIrRaPTZs2eSJP32t78dHx+32WwnzpKdGsw4jjudzr6+PpfLBcWqFEUFAoE7d+6Mj4+7XK5jA8Lve8hQo9FIp9P5fL6dm20228DAgM/nGxoa2tnZAauwo5ygKMrr9cI2FV3eEWaTydTX1zc0NARfKsuy0WgMBAIjIyNqdUuSZF9fXzgcXllZgSC8wjOCIGxuboIE+uKLL+7evev3+0/WjYD/+c9/Pq2wF5RN1et1HMctFsvg4OBHH330y1/+8s6dOycucj7FuE2hUPj2229nZmbAZlYr5qGhoc8//3x0dLRYLObzeajvVGxjyBaAc9Xf33/37t2f/vSnYFIcxl5gEur1+mq12mg0wMQLhUJ3796dnp4Oh8OKpaLX6w0GgyRJyWQSBmKq1wxxtGw2m06nRVG0Wq0Wi0VdV4l1V9x/atxMkqTX67137x7DMPF4vFarORyOoaGhiYmJH1oQ+Z5g5jgun8+3O+hKqjEYDP76179uNBomkykSiYCxhuM4hI6dTifU3n700UfhcLi3t/foZAZJkqFQ6Fe/+pXX693b2+N5vre3d3BwcHJy0mKxqH/TZDJNTk5+8cUXUNGsVisQAM5kMoIglMvlnZ2dhw8fBoNB8FHNZjNUjBxb3HJqMEMYdmhoyOl03rx5U5ZlaE4BbYedN4Hpy/O8Wu8q3Az9XQaD4fr163/84x+DwSBU5QGvMAxjt9shHQnWYjfRR9C7o6OjXq93f38fwzCDwdDT02OxWDQHotfrvV7vo0ePIO62uLiYzWYV6Q0B4EKhsLy8DI+XATPC5XJ1We93yiYYjuNms5mmaY/Ho/i+F6fJTBRFqBBtXzYYSqBQR0ZGfD7f3t4e1P2DtQ9MY7FYlHngXeoyo9Ho9/uVAznsxhME0dPT8+jRIxDI8/PzkC1VB0x4nt/Z2clms8vLyxaLxeFwBIPBqampn/zkJ8dOID/9RCSU+GDnNFH4aJdPme+tXjC42ooxBT6P3W4H/aecndqJ+KFnclgURXPbenp6Pv30U3iq08rKSiaT0dShQvVgtVrN5/PpdBqqgLt5CMxZJCIvAjWbzUwmk8lk2kNgBEG0PwnqXBQNjuM+n++zzz6zWCz//Oc/X716FY/HwUTQVOMow2+7qfd7XzBfNFLyfYVCoX0oCvRaXpBhViRJ9vb2fvrpp2AHfPPNN+vr69lstmPB7/mERy4yzNVqNZ1Od+zSADO7m3amM+Nph8MxMTHR29s7PDz81VdfLS0tRSIRTQoELMdu6v2uEMy1Wg36oNptH7fbDYmEi7NgkDH9/f0Mw/T19T158uTVq1fb29vQkwBaxuFwhEKhqampmzdvHl3vd1VgxjCsXq+rOzzUMPf29h6WgThfpCGhAoGHkZGReDyeSqXAU7Db7R6PBx4Cc2y939WCub01DSLPEMq+mNNFlBJHj8cDMRZRFCmKgvTlOYRHLrjQhkR9u5kNML/vB67+SAK2Zhim3cfrMq9zVWDmeb49zAkpI4ZhPoiZsT/Gx9NfEZgP0800TcPsm8t9AlcFZiiLb/emSJJUOnQQzB88aVqE1dbs5X6I3dWCuWPXD/bfx59d+u1fFZiPGMZzFUh/RVi5+zEKCOYPm5s7DinQDEVBMH/YBEMC21n5jGdnIpjfI8HkqPa8BaYaHYRg/uBJEIRCodA+h0vp0UK6+TJoZZ7n8/m8euqBwsoMwxw9URHB/MHAXCgUEolEx2QzPLkSwfzBkyRJe3t7kUhEE+yELGRvb+/JBk4gmC8WcRy3traWSCTaS3ctFgvURCKYP3g/6uDgIBaLdVTMDoejr6/vKjy58pLDDFVgHMe1O80kSQaDwYGBgW6KqBHMF5ogkNk+cRPHcY/HMz4+HgwGr8Kzhi8/zDabbXBw0OPxgH8MvrLNZoORW263+ypEDoirAPPY2Nj09LQoint7e7IsMwxz48aN3//+92NjY1dBYmMYdvkfwSpJUjabXVxcnJ+f39zcbLVaPp/v3r1709PTfX19V+Tp8JcfZqgQKhaLe3t7+Xy+1WpBN/qPH52HYL5wSMNz3WDaHgwtviK5qSsEswL2JXuOK4IZ0VVyqBAhmBHMiBDMiBDMiBDMiBDMiBDMiBDMiBDMiBDMCGZECGZECGZECGZECGZECGZECGZECGZECGYEMyIEMyIEMyIEMyIEMyIEM6IT0v8AD5TF0YHzW0sAAAAASUVORK5CYII=';
     }
@@ -84,18 +94,9 @@ export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps,
       baseUrl = layer.getSource().getUrl();
     }
 
-    const [minX, minY, maxX, maxY] = extent;
-    const centerX = (minX + maxX) / 2.0;
-    const centerY = (minY + maxY) / 2.0;
-    const dy = maxY - minY;
-    const calulatedQuadraticExtent = [
-      centerX - dy / 2,
-      centerY - dy / 2,
-      centerX + dy / 2,
-      centerY + dy / 2
-    ];
+    const height = width! / ratio!;
 
-    // TODO configurable!
+    // TODO configurable WMS parameters!
     const baseParams =
       '?SERVICE=WMS&' +
       'VERSION=1.1.0&' +
@@ -103,11 +104,11 @@ export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps,
       'FORMAT=image/png&' +
       'TRANSPARENT=true&' +
       'LAYERS=' + layer.getSource().getParams().LAYERS + '&' +
-      'HEIGHT=128&' +
-      'WIDTH=128&' +
+      'HEIGHT='+Math.round(height)+'&' +
+      'WIDTH='+Math.round(width!)+'&' +
       'SRS='+projection+'&' +
       'STYLES=&' +
-      'BBOX=' + calulatedQuadraticExtent!.join(',');
+      'BBOX=' + extent.join(',');
     return baseUrl + baseParams;
   }
 
@@ -128,7 +129,9 @@ export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps,
       layer,
       onClick,
       onMouseEnter,
-      onMouseLeave
+      onMouseLeave,
+      width,
+      ratio
     } = this.props;
 
     const {
@@ -143,16 +146,16 @@ export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps,
       <div
         className={`layersetentry${layer!.getVisible() ? ' selected' : ''}`}
         onMouseLeave={onMouseLeave}
+        style={{
+          width: `${width}px`,
+          height: `${width!/ratio!}px`
+        }}
       >
-        <div className="title-div">
-          <b>{layer!.get('name')}</b>
-          <div className="loading-div">
-            <SimpleButton
-              size="small"
-              loading={isLoading}
-            />
+        <Spin spinning={isLoading}>
+          <div className="title-div">
+            <b>{layer!.get('name')}</b>
           </div>
-        </div>
+        </Spin>
         <img
           data-identifier={layer.ol_uid}
           onClick={onClick}

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+
+import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlSourceImageWMS from 'ol/source/ImageWMS';
+import OlLayerGroup from 'ol/layer/Group';
+
+import { SimpleButton } from '@terrestris/react-geo';
+
+import './LayerCarouselSlide.less';
+
+// default props
+export interface DefaultLayerCarouselSlideProps {
+  layer: any;
+  extent: number[];
+  mapSize: number;
+  projection: String;
+}
+
+export interface LayerCarouselSlideProps extends Partial<DefaultLayerCarouselSlideProps> {
+  onClick: (evt: React.MouseEvent) => void;
+  onMouseEnter: (evt: React.MouseEvent) => void;
+  onMouseLeave: () => void;
+}
+
+export interface LayerCarouselSlideState {
+  isLoading: boolean;
+}
+
+/**
+ * Class representing the layer carousel slider component.
+ *
+ * @class The Slide.
+ * @extends React.Component
+ */
+export class LayerCarouselSlide extends React.Component<LayerCarouselSlideProps, LayerCarouselSlideState> {
+
+  /**
+   *Creates an instance of Slide.
+   * @param {SlideProps} props
+   * @memberof Slide
+   */
+  constructor(props: LayerCarouselSlideProps) {
+    super(props);
+
+    this.state = {
+      isLoading: true
+    }
+
+    // bindings
+    this.onLoad = this.onLoad.bind(this);
+  }
+
+    /**
+   *
+   * @param layer
+   */
+  getLayerPreview(layer: any) {
+    const {
+      extent,
+      projection
+    } = this.props;
+
+    if (!extent) {
+      return;
+    }
+
+    if (!layer) {
+      return;
+    }
+
+    // TODO: nicer image
+    if (layer instanceof OlLayerGroup) {
+      return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKIAAACiCAIAAABNkIFMAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4wURDS8BEYLnrgAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAZGUlEQVR42u1d2VMb2blvqTetrV0CCdRiMcYyNovHniF2Uk6mJo4zU5VKZXnIX5M/KJWH1KRck8SOZzIw2GYxGANjQAtCEhJCe7da6lbrPnw3ffu2BGgYDBjO9+CyBEjnnN/59qV1rVYLQ3TZSY+OAMGMCMGMCMGMCMGMCMGMCMGMCMGMCMGMYEaEYEaEYEaEYEaEYEaEYEaEYEaEYEaEYEYwI0IwI0IwI0IwI0IwI0IwI0IwI0IwI0IwI5gRIZgRIZgRIZgRIZgRIZgRIZgRIZgRIZgRzIgQzIgQzIgQzIgQzIgQzIgQzIi6J6LL32v9l+Cl7r+ETvCHknpI6pkdINHNsprNZq1Wq1artVpNlmWKogwGA03TNE3jOK7X6xHqXQIsy3Kj0ZAkCcMwgiAoioLTO2eYW62WKIr5fH5nZycajWaz2Xq9rtfrGYZhGMZmszEM43A4TCaTyWQym80EQej1es3NPXYbrVZLp6LLirEkSZVKpVgschyHYZjZbLbb7VarlSCI973rY2CWZblUKq2trc3Ozi4vL6dSKY7j9Ho9RVEWi8VsNjMM4/P53G632+32er0Oh4NhGGXROp1OgVCv1zebTXgJ8OM4LssyhmF6vZ6mabPZbLFYjEYjjuOXD2xZliuVSjwej8fj2WwWwzCv18uyLMuyNpsNx/Fzg7nVatXr9Ww2u7a2NjMzs7KyUiqVJEkCqHAcx3GcJEmKoqxWK8MwLpfLZrO53W6DwYDjeLPZlGVZr9fr9XrYBtzoVqsF7wDerVaLJEmHw9HX1zc4OMiyrNPpJEnyMiHdarUajUaxWIzH4y9fvtzc3MQw7Nq1axiG2Ww2o9FoMBje636P4WZJksrlcjKZjMfjuVwOQNL8jk6n29/fx3EclA1JkgRBEAQBnAqrh38VIw6YW/lzkiStVmswGLxz5879+/dv3brldDrf9wU/Y5IkieO4bDa7ubn5+vVreDMUCnEcB6r6Qljaal2rQRpeNptNURRrtdrR+rWjttbpdARBpFIpnudtNpvP5zObzUajEdl0ZwQzQRAMwwQCgWAwWCwWi8WiJEkgjbu8BIeRoraVW1IoFHZ2dlKpVLlcPoMLftYHTRBms9nr9YKsBqHt9XrBbj1PmHU6HU3TXq83HA4Xi0Wz2RyLxXK5XKVS4XleFEUFUfTAjGPvNEVRdrudZVmQ1YoJZrfbKYo6Z0tbr9fbbLZwOGyxWK5du7a7uwueVSKRyOVyHMeJogjiWpZlBWy9Xq9wtiKl1TvpKLRtNlswGPT7/QzDnMEFP2PS6/VWqxXsao1DpXZB39c9O5YR1eERjuMqlUo6nX737l0ymcxms5VKZX9/P5fLlctlQRBarRa4zqCnG42G4jJRFGU0GimKAhv7qplg5xse0XUpb1sqEkWxVCrlcjme58vlcqFQiMVi2Ww2n88D14qiGIvFNjY2Dg4OlC253e7R0dGBgQGGYcAZuzoO1QcQ7FQWpKyJIAiDweB2uwGkZrMJqAuCUK/XKYpKJpNPnjyJRqPqnVAUNTIy8vjx44GBAXjzSoVHzh7akztUGm2qvFRQh9tK07TNZlN8ZeVPbDbb4ODg6OioRiBfhWDnhXaoToB6s9kEE0xtlCm2GMS/Lp/evegG4Pv4UFmWm80mRLA1MCPX6/LALIoiz/PNZlPN7hAAPwPnAdFZwCzLMnhfoihqwkA0TRsMBnTolwFmSZIKhUK5XG40GupEhclkslqtNE0jI+uDhxlyl4VCoVQqqYU2juM2mw0KEBDMlwFmjuOKxWKlUlHDTJKk3W53uVwo73RJYBYEgeM4qBpT7C+KohwOh8PhuHzB6iuqmyGaXa/X1XkLiFojif1hh0c0MEPaClMF9sCbOoPaNkRnBDPUPaFgyCXXzTqdrr28RKkIQ8BfnvBIewYChDY67ssDc7PZFARBXcwFiQ2TyXQG1TCIzkI3Q+4ZavbUITDIJR8b6VQXL7QXEp1ZmvKw2iYE8/+eTq1Wy2azuVyuVqspahjHcavVarfbj4iNQPVMrVbjOA7KE5SKA1mWoZABmjzea7hUkqRarQYOIRQ7WK3WSyCEThnmarW6t7enKdwnCMJutzudzo69BRBR2d/fTyQS6XQ6nU6Xy+VqtSpJksLBFEWZTKb+/v6BgYHh4WGn03nqYRZZlsvlciqVikQi2Wy2XC4bDAaPxzMwMDA4OMgwzI/MrZ1LbdD7glkQhGKxWK1WlUinEhux2+3tjAg9Wuvr6wsLC99//30kEsnlctDCo6SrQewbjUaPx3Pjxo1PPvnkwYMHfX19J2YySIeDmAHwRFHMZDKLi4tzc3MbGxu7u7uCIJAkGQgEpqamHj58ODExodTDnOBYZFmu1+tKWRxN02dT6fe+dHPjv6S+vARBWCwWq9XaXhtULBbn5uaePHmytLQUi8Ugr6WuR/g/W1Gvj8Vi29vb0Wi0UCg8fvyYZdkfKsAhSQrMimEYwzBer5cgiEQi8eTJk6dPn66uru7v7wuCAP7C9vZ2KpWSZdlqtY6NjdE0fQKMoUJS86U2m+0syxpPGWYNF6q5uR0SjuNWVlb+9re/zczMxGIxJQyuLh9T/t9sNiVJSqfTtVpNkiSapj///HO/39+99JZlOZ/Pr66urqyspNPpVqvl9/vD4bDdbn/69Onf//739fV1pRcQ/qRSqWxubi4sLNy8eTMYDLrd7h8KTLPZzOfza2tra2tryWQSw7BAIBAOh8PhsNvtPrMI/yl/DY7j7fVA0EWnYeVms5lOp7/77ruFhYVIJKI22Y7gjGazWSwWV1dXe3p6hoeHocG6y6PnOO7169d/+ctf5ufnM5kMhmFerxdqwufn51dXV8vlsjqrpnB/PB7f2dnhOM7lcv0gmMEm3dnZmZmZmZmZicfjGIaxLFsoFKBt2GKxdNP8rZ4ToaEuHZDTN2TUvKj5kfplrVbb3t5+8+ZNPB6HOv7D1q3ZJyC9sbGxvb0dDoetVms3R99oNDY2Nv7xj388f/48FotBZxA0Elit1r29vVKp1LExTJZlnudLpVI3F7GjTRqJRJaWlpaXl/P5PIZhxWLRZDJdu3atv7/fbDYfsXhZlgVBqFar1WoV9Ig69ASOgMlk6qbq+ZRhBobTcLP6TeUdjuOSyWQsFqtWq5qUpclkUtYNZWUcx6k/QZKkfD6fSqWq1eqxRw8cGYvFnj59+vXXXycSCcV0aDQamUymUChoINQEZSVJEkXxBN17rVaL5/lkMplIJEqlElRNlUqlRCKRTCZ5nj9i8Y1GI5/Pb21txWKx3d1dpRpHGQECTVmBQGBwcDAYDB7dw3DKljYEtNs7Y5vNpvrsYP+ZTAZaLNU2uc/nGx0dHRoagqylIAhra2urq6sHBweKRIUaFY7jNLZeO8Acxx0cHGxsbHz33XfPnz/f3NyEDKnaPpIkqb0BTFmt0nJwsjOp1+tKJ6lyaeCder1+2LKr1WosFpubm4Oe92w2KwiCKIqwKpgMAJUa/f39k5OTx3YknT43d/QvleY5NU6CIGiqD4xG48jIyB/+8IfJyUmKojAMEwTh66+/Bi9LDUa7Fmjnhv39/Y2NjaWlpfn5+fX19d3d3UqlovkrjUaAEwTVoFY9J24EgbAP6Ajl3oiiqHSXtXukqVTqzZs3s7Ozc3NzkUgkn89DJ2K7Pk4mk7u7uzzPOxyOo5vCTxPmI8yB9h9BvEmDHE3TQ0NDk5OTY2NjYIUWi8Xl5WWNRQrlwDD6ouPXCYIQj8efP3++sLCwuLiYSqWKxSKcbDv3q80CgiBIklTy5WoT8sRWcXtnQsdlQAjh7du3//nPf168ePH27dtMJsPzfMdfhtWCXxOPx5PJ5NFN4adv0B/Gze27gg0o8CuKGQoQoMMql8ttbW1By516t0aj0Wq1Go3Gjpp4c3Pzq6++gnkp+/v7EDrt6KdpDg5iF+rWbZ1OZzAYjEZj+3d1Hx7vCLNGvJVKpbm5uS+//PLFixfRaBQqoE8rb3vKMB8h2dp/pGCvPlO1dhEE4fvvvwcbVS3bCYJwOBw9PT1qSxWEYS6Xe/PmzdOnT0FQa+4HXCnN+apXCOFY9XdBh7fH4zlZsSKA2p6G0fBotVpdXFz861//Ojs7G4vFwPVoj48q/wJBUzjLsoFA4Oim8NPXzeoMD3Z4W03HI5NlWTFrQRy9fPkyEomoPS5g5f7+fnBI4K5AyUoymZydnf33v//9+vVrYAh1ogzDMJIkYcRRR0aB5i6N1oR5DYFAwGKxnCCsrTT3trO4cgL1ej0SifzrX/+an58HjDWaGAwumqaNRiM0oWlMsHA47PV6j4gJnj7M3VxeNdLKhsHL2traWllZAcvlxYsX33zzzd7entogIggC5mQMDAwomU0Q77Ozs19++eXCwkIqlarX60o9mpLwttlser0ejHaN8Q+ChCAItZ+j1+stFkswGAwEAicri+gY2VCfD6z822+/ffnyZTQaVWMMAFMUZbPZent7Q6EQ2FngU2kcKtja2QntYy+vwjqwLLWQ5Hl+cXGxXq+zLFuv17e2tra3tzmOU4NhMpnATOvp6VHGjQmCkEwmNzY2VldXd3d3FY4E8Ewmk8/nC4VCfX19mUxmfn4exkJo1glAqq+UTqeDgSEul+sEXZygR9QXDmurl6rValtbW6urq+/eveM4TjkKiH44nU6WZW/dujU2NgZxWcU5Ps/wSEeB3NnEJwiDwUCSpMaLhRA/TM5SPC5F8BIE0dvbe+/evZs3b5pMJuXTRFGsVCqZTObg4ECDscPhuH79+q1btz755BOj0fjs2bOlpaWORiJBEJpIDkmSHo8HxqGcQDE3m81KpVIoFBqNBvb/Jy0pwxo4jkskEhsbG/l8XrlhUIgxMDAwMTHxs5/97Pbt28Fg0G63t2vf8wl2KjtR28/tho9OpzObzW63G9JWyhWGMYAcx/E8j7VNoNLr9Q6HY2pq6uOPP+7p6dHIKJBjMM0DFkCSpMvlGh8fn56efvToEcuyu7u7s7OzHQ8FtB3Y/8oH0jTtdrt9Pt8J7C+QMdlsFgadqrcPlXEQ/4do4MHBgWIuwPeyLPvw4cPf/e53o6Ojaia+EJZ2s9kEGaWxvDQiBWBmWXZgYCAajWoqQTvqMxzHGYYJh8P3798fHx83m83qn1IU5fF4WJYNhUKNRoPjOJIk3W737du3Hzx48OjRo1AoRBBENpuFS9BuD4Lyrlarmo91OBx2ux2KWNRTFbqBGQYkZrNZdXMojuPgDUL8B8J56rgNwBwKhT777LM7d+6cSg/DacIM00fBT9UkMDThBZ1OZ7FYrl+/fvv27Wg0+u7dO40trRH4MIVubGzsF7/4xc9//nO3261mZTgXn883NTXVaDRYli0Wi0ajkWXZycnJ6elpMKBAJAJg7V9EkqTJZAIpok6hMgwDgeh6vS6KIkmSBoPBarUey16Q94xEIsViUZ2cJQjC6XR6vV5IT0mSpJhdiswD3eT3+09rludpwszzfCwWS6fTgiCoNQcM39a0XOA43t/f//jx42KxKMtyPB4HE1fj4+I4TlEUTCG6f//+b37zm8HBQeADjci12+1jY2MOh2N8fJzneaPR2NvbC3OJlBsG5l47zLBIq9UKSSS1uZDL5RYXF9++fVupVFqtls1mCwQCoVDI7/cfLckhBQn5FQVFZToYy7KKQFK7/uogzwlyYu8dZlmWDw4Otra20um0puvCaDS6XC5N0g1Odmxs7E9/+pPdbl9ZWdne3oaMm6IpKYqCWovR0dFwOPzgwYNQKNSxhAM4D5Q9y7JQJWg2mzXzEWRZBqe8XWhDTE0x/hWpu7i4uLOzI0kSz/NwmW7cuPHxxx9PT0/39/e3Xzh1bmZ/f393d7dWq6kvt8vlunHjBsuycEvAG1aLOlDq0Wg0EoncunWry0zrGcEsiuLOzk4sFiuVSmqOpGm6p6fH4/GoDWO16L59+7bH43nz5k0ikchms7VaTRRFYGIoLQoEAn6/PxQKud3uI5xXkIeg+Q6LsMLg8vZ0EwhSu92umX4ESfFoNKrIAJqm9/b2cBwPBALQ49kRAygoyGQyUKqgrn70er3Dw8NerxdMMJAiauEMeZ1YLPbs2bPh4eGJiYkfL7pPB2a4vJVKpVqtqhUzyCgA6bAUutFoDIVCHo+H4ziO4xQLDpCGWdNms7nLrR5tH0FFoibED3LF7/e73W6apjVpck3dkiiKyWQSShNrtdphE88BKkiBqCUHiByn06nUKxqNRofDAZ+jLKzZbOZyuVevXoETFQ6HNSbnOZtgmimNNE339/dPTEwEAoEjwgtwG8xms1rUa/yxU/ECyuVyexYEzP7BwUGn0wmPJAA3tz3ofdg7HW8bDLQzmUwQXlXuk9vtdjgccBogz1iW9fv96+vr6vS5KIrRaPTZs2eSJP32t78dHx+32WwnzpKdGsw4jjudzr6+PpfLBcWqFEUFAoE7d+6Mj4+7XK5jA8Lve8hQo9FIp9P5fL6dm20228DAgM/nGxoa2tnZAauwo5ygKMrr9cI2FV3eEWaTydTX1zc0NARfKsuy0WgMBAIjIyNqdUuSZF9fXzgcXllZgSC8wjOCIGxuboIE+uKLL+7evev3+0/WjYD/+c9/Pq2wF5RN1et1HMctFsvg4OBHH330y1/+8s6dOycucj7FuE2hUPj2229nZmbAZlYr5qGhoc8//3x0dLRYLObzeajvVGxjyBaAc9Xf33/37t2f/vSnYFIcxl5gEur1+mq12mg0wMQLhUJ3796dnp4Oh8OKpaLX6w0GgyRJyWQSBmKq1wxxtGw2m06nRVG0Wq0Wi0VdV4l1V9x/atxMkqTX67137x7DMPF4vFarORyOoaGhiYmJH1oQ+Z5g5jgun8+3O+hKqjEYDP76179uNBomkykSiYCxhuM4hI6dTifU3n700UfhcLi3t/foZAZJkqFQ6Fe/+pXX693b2+N5vre3d3BwcHJy0mKxqH/TZDJNTk5+8cUXUNGsVisQAM5kMoIglMvlnZ2dhw8fBoNB8FHNZjNUjBxb3HJqMEMYdmhoyOl03rx5U5ZlaE4BbYedN4Hpy/O8Wu8q3Az9XQaD4fr163/84x+DwSBU5QGvMAxjt9shHQnWYjfRR9C7o6OjXq93f38fwzCDwdDT02OxWDQHotfrvV7vo0ePIO62uLiYzWYV6Q0B4EKhsLy8DI+XATPC5XJ1We93yiYYjuNms5mmaY/Ho/i+F6fJTBRFqBBtXzYYSqBQR0ZGfD7f3t4e1P2DtQ9MY7FYlHngXeoyo9Ho9/uVAznsxhME0dPT8+jRIxDI8/PzkC1VB0x4nt/Z2clms8vLyxaLxeFwBIPBqampn/zkJ8dOID/9RCSU+GDnNFH4aJdPme+tXjC42ooxBT6P3W4H/aecndqJ+KFnclgURXPbenp6Pv30U3iq08rKSiaT0dShQvVgtVrN5/PpdBqqgLt5CMxZJCIvAjWbzUwmk8lk2kNgBEG0PwnqXBQNjuM+n++zzz6zWCz//Oc/X716FY/HwUTQVOMow2+7qfd7XzBfNFLyfYVCoX0oCvRaXpBhViRJ9vb2fvrpp2AHfPPNN+vr69lstmPB7/mERy4yzNVqNZ1Od+zSADO7m3amM+Nph8MxMTHR29s7PDz81VdfLS0tRSIRTQoELMdu6v2uEMy1Wg36oNptH7fbDYmEi7NgkDH9/f0Mw/T19T158uTVq1fb29vQkwBaxuFwhEKhqampmzdvHl3vd1VgxjCsXq+rOzzUMPf29h6WgThfpCGhAoGHkZGReDyeSqXAU7Db7R6PBx4Cc2y939WCub01DSLPEMq+mNNFlBJHj8cDMRZRFCmKgvTlOYRHLrjQhkR9u5kNML/vB67+SAK2Zhim3cfrMq9zVWDmeb49zAkpI4ZhPoiZsT/Gx9NfEZgP0800TcPsm8t9AlcFZiiLb/emSJJUOnQQzB88aVqE1dbs5X6I3dWCuWPXD/bfx59d+u1fFZiPGMZzFUh/RVi5+zEKCOYPm5s7DinQDEVBMH/YBEMC21n5jGdnIpjfI8HkqPa8BaYaHYRg/uBJEIRCodA+h0vp0UK6+TJoZZ7n8/m8euqBwsoMwxw9URHB/MHAXCgUEolEx2QzPLkSwfzBkyRJe3t7kUhEE+yELGRvb+/JBk4gmC8WcRy3traWSCTaS3ctFgvURCKYP3g/6uDgIBaLdVTMDoejr6/vKjy58pLDDFVgHMe1O80kSQaDwYGBgW6KqBHMF5ogkNk+cRPHcY/HMz4+HgwGr8Kzhi8/zDabbXBw0OPxgH8MvrLNZoORW263+ypEDoirAPPY2Nj09LQoint7e7IsMwxz48aN3//+92NjY1dBYmMYdvkfwSpJUjabXVxcnJ+f39zcbLVaPp/v3r1709PTfX19V+Tp8JcfZqgQKhaLe3t7+Xy+1WpBN/qPH52HYL5wSMNz3WDaHgwtviK5qSsEswL2JXuOK4IZ0VVyqBAhmBHMiBDMiBDMiBDMiBDMiBDMiBDMiBDMiBDMCGZECGZECGZECGZECGZECGZECGZECGZECGYEMyIEMyIEMyIEMyIEMyIEM6IT0v8AD5TF0YHzW0sAAAAASUVORK5CYII=';
+    }
+
+    if (!(layer.getSource() instanceof OlSourceTileWMS) &&
+        !(layer.getSource() instanceof OlSourceImageWMS)) {
+      return '404';
+    }
+    let baseUrl;
+    if (layer.getSource().getUrls) {
+      baseUrl = layer.getSource().getUrls()[0];
+    } else {
+      baseUrl = layer.getSource().getUrl();
+    }
+
+    const [minX, minY, maxX, maxY] = extent;
+    const centerX = (minX + maxX) / 2.0;
+    const centerY = (minY + maxY) / 2.0;
+    const dy = maxY - minY;
+    const calulatedQuadraticExtent = [
+      centerX - dy / 2,
+      centerY - dy / 2,
+      centerX + dy / 2,
+      centerY + dy / 2
+    ];
+
+    // TODO configurable!
+    const baseParams =
+      '?SERVICE=WMS&' +
+      'VERSION=1.1.0&' +
+      'REQUEST=GetMap&' +
+      'FORMAT=image/png&' +
+      'TRANSPARENT=true&' +
+      'LAYERS=' + layer.getSource().getParams().LAYERS + '&' +
+      'HEIGHT=128&' +
+      'WIDTH=128&' +
+      'SRS='+projection+'&' +
+      'STYLES=&' +
+      'BBOX=' + calulatedQuadraticExtent!.join(',');
+    return baseUrl + baseParams;
+  }
+
+  /**
+   *
+   */
+  onLoad() {
+    this.setState({
+      isLoading: false
+    })
+  }
+
+  /**
+   * The render function.
+   */
+  render() {
+    const {
+      layer,
+      onClick,
+      onMouseEnter,
+      onMouseLeave
+    } = this.props;
+
+    const {
+      isLoading
+    } = this.state;
+
+    if (!layer) {
+      return null;
+    }
+
+    return (
+      <div
+        className={`layersetentry${layer!.getVisible() ? ' selected' : ''}`}
+        onMouseLeave={onMouseLeave}
+      >
+        <div className="title-div">
+          <b>{layer!.get('name')}</b>
+          <div className="loading-div">
+            <SimpleButton
+              size="small"
+              loading={isLoading}
+            />
+          </div>
+        </div>
+        <img
+          data-identifier={layer.ol_uid}
+          onClick={onClick}
+          onLoad={this.onLoad}
+          onMouseEnter={onMouseEnter}
+          src={this.getLayerPreview(layer)}
+          alt={layer!.get('name')}
+        />
+      </div>
+    );
+  }
+}
+export default LayerCarouselSlide;

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
@@ -105,7 +105,7 @@ export class LayerCarouselSlide extends React.PureComponent<LayerCarouselSlidePr
       'TRANSPARENT=true&' +
       'LAYERS=' + layer.getSource().getParams().LAYERS + '&' +
       'HEIGHT='+Math.round(height)+'&' +
-      'WIDTH='+Math.round(width!)+'&' +
+      'WIDTH=' + Math.round(width!) + '&' +
       'SRS='+projection+'&' +
       'STYLES=&' +
       'BBOX=' + extent.join(',');

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
@@ -99,7 +99,7 @@ export class LayerCarouselSlide extends React.PureComponent<LayerCarouselSlidePr
     // TODO configurable WMS parameters!
     const baseParams =
       '?SERVICE=WMS&' +
-      'VERSION=1.1.0&' +
+      'VERSION=1.1.1&' +
       'REQUEST=GetMap&' +
       'FORMAT=image/png&' +
       'TRANSPARENT=true&' +

--- a/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
+++ b/packages/baseclient-components/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
@@ -43,7 +43,7 @@ export class LayerCarouselSlide extends React.PureComponent<LayerCarouselSlidePr
   };
 
   /**
-   *Creates an instance of Slide.
+   * Creates an instance of Slide.
    * @param {SlideProps} props
    * @memberof Slide
    */

--- a/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.less
+++ b/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.less
@@ -1,0 +1,73 @@
+.react-geo-layertree-node {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid lightgray;
+
+  // let settings icon never be transparent
+  // (even if layer is out of scale or inactive)
+  &.out-off-range {
+    opacity: 1;
+
+    .layer-tree-node-title-filter,
+    .layer-tree-node-title-active,
+    .layer-tree-node-title-layername,
+    .layer-tree-node-title-visibility,
+    .layer-tree-node-title-inactive {
+        opacity: .5;
+    }
+  }
+
+  .ant-tree-switcher {
+    display: none !important;
+  }
+
+  span.ant-tree-checkbox {
+    display: none !important;
+  }
+
+  .ant-tree-node-content-wrapper {
+    flex: 1;
+    overflow: hidden;
+    height: 100%;
+
+    .layer-tree-node-list-item {
+      .ant-slider {
+        margin: 5px 7px 5px;
+      }
+    }
+
+    .layer-tree-node-title {
+      display: flex;
+      flex: 1;
+      align-items: center;
+
+      .layer-tree-node-title-layername {
+        margin-left: 12px;
+        flex: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .layer-tree-node-title-visibility.layer-tree-node-title-inactive {
+        opacity: 0.5;
+      }
+
+      .layer-tree-node-title-settings {
+        margin-right: 12px;
+        width: 12px;
+      }
+
+      .layer-tree-node-loading-active {
+        margin-right: 12px;
+        width: 12px;
+      }
+
+      .layer-tree-node-loading-inactive {
+        margin-right: 12px;
+        width: 12px;
+        display: none;
+      }
+    }
+  }
+}

--- a/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.less
+++ b/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.less
@@ -1,7 +1,11 @@
+@layer-tree-node-height: 48px;
+
 .react-geo-layertree-node {
   display: flex;
   align-items: center;
   border-bottom: 1px solid lightgray;
+  padding: 0 !important;
+  height: @layer-tree-node-height;
 
   // let settings icon never be transparent
   // (even if layer is out of scale or inactive)
@@ -28,10 +32,14 @@
   .ant-tree-node-content-wrapper {
     flex: 1;
     overflow: hidden;
-    height: 100%;
+    height: @layer-tree-node-height !important;
 
     .layer-tree-node-list-item {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
       .ant-slider {
+        flex: 1;
         margin: 5px 7px 5px;
       }
     }

--- a/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.spec.tsx
+++ b/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.spec.tsx
@@ -1,0 +1,29 @@
+/*eslint-env jest*/
+import TestUtils from '../../../spec/TestUtils';
+
+import LayerLegendAccordionTreeNode from './LayerLegendAccordionTreeNode';
+
+describe('<LayerLegendAccordionTreeNode />', () => {
+  let wrapper: any;
+
+  beforeEach(() => {
+    wrapper = TestUtils.shallowComponent(LayerLegendAccordionTreeNode, {
+      t: (t: string) => t
+    }, {});
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(LayerLegendAccordionTreeNode).not.toBe(undefined);
+    });
+
+    it('can be rendered', () => {
+      expect(wrapper).not.toBe(undefined);
+    });
+  });
+
+});

--- a/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.spec.tsx
+++ b/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.spec.tsx
@@ -4,11 +4,14 @@ import TestUtils from '../../../spec/TestUtils';
 import LayerLegendAccordionTreeNode from './LayerLegendAccordionTreeNode';
 
 describe('<LayerLegendAccordionTreeNode />', () => {
+  let layer;
   let wrapper: any;
 
   beforeEach(() => {
-    wrapper = TestUtils.shallowComponent(LayerLegendAccordionTreeNode, {
-      t: (t: string) => t
+    layer = TestUtils.createTileLayer({});
+    wrapper = TestUtils.mountComponent(LayerLegendAccordionTreeNode, {
+      t: () => {},
+      layer,
     }, {});
   });
 

--- a/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -1,0 +1,286 @@
+import * as React from 'react';
+import {
+  Tooltip,
+  Dropdown
+} from 'antd';
+
+import OlLayerGroup from 'ol/layer/Group';
+import OlTileWmsSource from 'ol/source/TileWMS';
+import OlImageWmsSource from 'ol/source/Image';
+
+import {
+  LayerTransparencySlider
+} from '@terrestris/react-geo';
+
+import './LayerLegendAccordionTreeNode.less';
+
+// default props
+interface DefaultLayerLegendAccordionNodeProps {
+  layer: any
+}
+
+interface LayerLegendAccordionNodeProps extends Partial<DefaultLayerLegendAccordionNodeProps>{
+  t: (arg: string) => {};
+}
+
+interface LayerLegendAccordionNodeState {
+  loadingQueue: String[]
+}
+
+/**
+ * Class representing the LayerLegendAccordionNode.
+ *
+ * @class LayerLegendAccordionNode
+ * @extends React.Component
+ */
+export default class LayerLegendAccordionNode extends React.Component<LayerLegendAccordionNodeProps, LayerLegendAccordionNodeState> {
+
+  public static defaultProps: DefaultLayerLegendAccordionNodeProps = {
+    layer: null
+  };
+
+  constructor(props: LayerLegendAccordionNodeProps) {
+    super(props);
+
+    this.state = {
+      loadingQueue: []
+    };
+
+    // binds
+    this.loadingStartHandler = this.loadingStartHandler.bind(this);
+    this.loadingEndHandler = this.loadingEndHandler.bind(this);
+    this.onLayerTreeNodeVisibilityChange = this.onLayerTreeNodeVisibilityChange.bind(this);
+    this.registerLoadingEventsForOlLayer = this.registerLoadingEventsForOlLayer.bind(this);
+  }
+
+  /**
+   * The componentWillMount lifecycle function
+   *
+   * @memberof LayerLegendAccordionNode
+   */
+  componentWillMount() {
+    const { layer } = this.props;
+    if (layer) {
+      this.registerLoadingEventsForOlLayer(layer, true);
+    }
+  }
+
+  /**
+   * The componentWillUnmount lifecycle function
+   *
+   * @memberof LayerLegendAccordionNode
+   */
+  componentWillUnmount() {
+    const { layer } = this.props;
+    if (layer) {
+      this.registerLoadingEventsForOlLayer(layer, false);
+    }
+  }
+
+  /**
+   * Register loadstart and loadend handler for ImageWMS and TileWMS layers
+   * @param {OlLayer} layer The OpenLayers layer to register listener for
+   * @param {boolean} mode The mode: true => register handler, false => unregister handler
+   */
+  registerLoadingEventsForOlLayer(layer: any, mode: boolean) {
+    if (!layer.getSource) {
+      return;
+    }
+    const layerSource = layer.getSource();
+
+    if (layerSource instanceof OlTileWmsSource) {
+      if (mode) {
+        layerSource.on('tileloadstart', this.loadingStartHandler);
+        layerSource.on('tileloadend', this.loadingEndHandler);
+        // on error: stop loading indicator for current tile
+        layerSource.on('tileloaderror', this.loadingEndHandler);
+        return;
+      } else {
+        layerSource.un('tileloadstart', this.loadingStartHandler);
+        layerSource.un('tileloadend', this.loadingEndHandler);
+        // on error: stop loading indicator for current tile
+        layerSource.un('tileloaderror', this.loadingEndHandler);
+        return;
+      }
+    }
+    if (layerSource instanceof OlImageWmsSource) {
+      if (mode) {
+        layerSource.on('imageloadstart', this.loadingStartHandler);
+        layerSource.on('imageloadend', this.loadingEndHandler);
+        // on error: stop loading indicator for current image
+        layerSource.on('imageloaderror', this.loadingEndHandler);
+        return;
+      } else {
+        layerSource.un('imageloadstart', this.loadingStartHandler);
+        layerSource.un('imageloadend', this.loadingEndHandler);
+        // on error: stop loading indicator for current image
+        layerSource.un('imageloaderror', this.loadingEndHandler);
+        return;
+      }
+    }
+  }
+
+  /**
+   * The handler called if tile / image starts loading
+   * @param evt The event
+   */
+  loadingStartHandler(evt: any) {
+    const layerNames = evt.target.getParams().LAYERS;
+    if (evt.target instanceof OlTileWmsSource) {
+      this.setState(prevState => ({
+        loadingQueue: [...prevState.loadingQueue, `tile-${evt.tile.ol_uid}_${layerNames}`]
+      }))
+    }
+    if (evt.target instanceof OlImageWmsSource) {
+      this.setState(prevState => ({
+        loadingQueue: [...prevState.loadingQueue, `IMAGEWMS_${layerNames}`]
+      }))
+    }
+  }
+
+  /**
+   * The handler called if tile / image is loaded / has thrown an error
+   * @param evt The event
+   */
+  loadingEndHandler(evt: any) {
+    const { loadingQueue } = this.state;
+    const layerNames = evt.target.getParams().LAYERS;
+
+    if (evt.target instanceof OlTileWmsSource) {
+      this.setState({
+        loadingQueue: loadingQueue.filter((lq: string) => lq !== `tile-${evt.tile.ol_uid}_${layerNames}`)
+      })
+    }
+    if (evt.target instanceof OlImageWmsSource) {
+      this.setState({
+        loadingQueue: loadingQueue.filter((lq: string) => lq !== `IMAGEWMS_${layerNames}`)
+      })
+    }
+  }
+
+  /**
+   * Handler called if visibility of a certain layers is changed
+   * @param {OlLayer[]} layer The layer for which the visibility has to be changed
+   */
+  onLayerTreeNodeVisibilityChange(layer: any) {
+    const nextLayerVisibility = !layer.getVisible();
+    layer.setVisible(nextLayerVisibility);
+
+    // we need to do this since legend needs to be redrawn
+    this.forceUpdate();
+  }
+
+  /**
+   *
+   *
+   * @returns
+   * @memberof LayerLegendAccordionNode
+   */
+  render() {
+    const {
+      layer,
+      t
+    } = this.props;
+
+    const {
+      loadingQueue
+    } = this.state;
+
+    if (!layer) {
+      return <div />;
+    }
+
+    const visibilityClass = layer.getVisible() ?
+    'fa-eye layer-tree-node-title-active' :
+    'fa-eye-slash layer-tree-node-title-inactive';
+    const visibilitySpanClass = `fa ${visibilityClass} layer-tree-node-title-visibility`;
+
+    if (layer instanceof OlLayerGroup) {
+      return (
+        <span
+          className="layer-tree-node-title"
+        >
+          <Tooltip
+            title={t('LayerLegendAccordion.toggleVisibilityTooltipText')}
+            placement="right"
+            mouseEnterDelay={0.5}
+          >
+            <span
+              className={visibilitySpanClass}
+              onClick={() => this.onLayerTreeNodeVisibilityChange(layer)}
+            />
+          </Tooltip>
+          <Tooltip
+            title={layer.get('name')}
+            placement="top"
+            mouseEnterDelay={0.5}
+          >
+            <span
+              className="layer-tree-node-title-layername"
+            >
+              {layer.get('name')}
+            </span>
+          </Tooltip>
+        </span>
+      );
+    }
+
+    const loadingSpanClass = `fa fa-spinner fa-spin layer-tree-node-loading-${loadingQueue.length > 0 ? 'active' : 'inactive'}`;
+
+    return (
+      <span
+        className="layer-tree-node-list-item"
+      >
+        <div className="layer-tree-node-title">
+        <Tooltip
+          title={t('LayerLegendAccordion.toggleVisibilityTooltipText')}
+          placement="right"
+          mouseEnterDelay={0.5}
+        >
+          <span
+            className={visibilitySpanClass}
+            onClick={() => this.onLayerTreeNodeVisibilityChange(layer)}
+          />
+        </Tooltip>
+        <Tooltip
+          title={layer.get('name')}
+          placement="top"
+          mouseEnterDelay={0.5}
+        >
+          <span
+            className="layer-tree-node-title-layername"
+          >
+            {layer.get('name')}
+          </span>
+        </Tooltip>
+        <span
+          className={loadingSpanClass}
+        />
+        {
+          !(layer instanceof OlLayerGroup) ?
+            <Dropdown
+              overlay={<div />} // TODO: make something more senseful here
+              placement="topLeft"
+              trigger={['click']}
+            >
+              <Tooltip
+                title={this.props.t('LayerLegendAccordion.layerSettingsTooltipText')}
+                placement="right"
+                mouseEnterDelay={0.5}
+              >
+                <span
+                  className="fa fa-cog layer-tree-node-title-settings"
+                />
+              </Tooltip>
+            </Dropdown> :
+            null
+          }
+          </div>
+          <LayerTransparencySlider
+            layer={layer}
+          />
+      </span>
+    )
+  }
+
+}

--- a/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/packages/baseclient-components/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -274,11 +274,11 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
               </Tooltip>
             </Dropdown> :
             null
-          }
-          </div>
-          <LayerTransparencySlider
-            layer={layer}
-          />
+        }
+        </div>
+        <LayerTransparencySlider
+          layer={layer}
+        />
       </span>
     )
   }

--- a/packages/baseclient-components/src/container/Header/Header.tsx
+++ b/packages/baseclient-components/src/container/Header/Header.tsx
@@ -20,6 +20,7 @@ interface DefaultHeaderProps {
 }
 
 interface HeaderProps extends Partial<DefaultHeaderProps>{
+  topic: string;
   map: any;
   i18n: any;
   t: (arg: string) => {};
@@ -82,8 +83,14 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
       map,
       title,
       loading,
+      topic,
       t
     } = this.props;
+
+    let titleString = title;
+    if (topic) {
+      titleString = `${title} (${topic})`;
+    }
 
     return (
       <header className="app-header">
@@ -127,7 +134,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
              md={11}
              lg={11}
           >
-            <span className="app-title">{title}</span>
+            <span className="app-title">{titleString}</span>
           </Col>
           <Col
             xs={1}

--- a/packages/baseclient-components/src/container/LayerLegendAccordion/LayerLegendAccordion.less
+++ b/packages/baseclient-components/src/container/LayerLegendAccordion/LayerLegendAccordion.less
@@ -30,6 +30,10 @@
     padding-top: 5px;
   }
 
+  .ant-divider.ant-divider-horizontal {
+    margin: 2px 0px;
+  }
+
   .layer-legend-accordion-title {
     span.fa {
       float: right;
@@ -75,80 +79,6 @@
       overflow: auto;
       background-color: #fafafa;
       border: 1px dotted lightgray;
-
-      .react-geo-layertree-node {
-        display: flex;
-        align-items: center;
-        border-bottom: 1px solid lightgray;
-
-        // let settings icon never be transparent
-        // (even if layer is out of scale or inactive)
-        &.out-off-range {
-          opacity: 1;
-
-          .layer-tree-node-title-filter,
-          .layer-tree-node-title-active,
-          .layer-tree-node-title-layername,
-          .layer-tree-node-title-visibility,
-          .layer-tree-node-title-inactive {
-              opacity: .5;
-          }
-        }
-
-        .ant-tree-switcher {
-          display: none;
-        }
-
-        span.ant-tree-checkbox {
-          display: none;
-        }
-
-        .ant-tree-node-content-wrapper {
-          flex: 1;
-          overflow: hidden;
-          height: 100%;
-
-          .layer-tree-node-list-item {
-            .ant-slider {
-              margin: 5px 7px 5px;
-            }
-          }
-
-          .layer-tree-node-title {
-            display: flex;
-            flex: 1;
-            align-items: center;
-
-            .layer-tree-node-title-layername {
-              margin-left: 12px;
-              flex: 1;
-              white-space: nowrap;
-              overflow: hidden;
-              text-overflow: ellipsis;
-            }
-
-            .layer-tree-node-title-visibility.layer-tree-node-title-inactive {
-              opacity: 0.5;
-            }
-
-            .layer-tree-node-title-settings {
-              margin-right: 12px;
-              width: 12px;
-            }
-
-            .layer-tree-node-loading-active {
-              margin-right: 12px;
-              width: 12px;
-            }
-
-            .layer-tree-node-loading-inactive {
-              margin-right: 12px;
-              width: 12px;
-              display: none;
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/packages/baseclient-components/src/container/LayerLegendAccordion/LayerLegendAccordion.tsx
+++ b/packages/baseclient-components/src/container/LayerLegendAccordion/LayerLegendAccordion.tsx
@@ -315,18 +315,21 @@ export default class LayerLegendAccordion extends React.Component<LayerLegendAcc
           key="tree"
           className="layertree-collapse-panel"
         >
-          <span
-            className={layerVisibilityClassName}
-            onClick={(event: React.MouseEvent) => {
-              this.onAllLayersVisibleChange(mapLayers);
-              event.preventDefault();
-            }}
-          >
-            <span>{layerVisibilityClassName !== 'fa fa-eye all-layers-handle' ?
-              t('LayerLegendAccordion.activateAllLayersText') :
-              t('LayerLegendAccordion.deactivateAllLayersText')}
-            </span>
-          </span>
+          {
+            mapLayers && mapLayers.length > 0 ?
+            <span
+              className={layerVisibilityClassName}
+              onClick={(event: React.MouseEvent) => {
+                this.onAllLayersVisibleChange(mapLayers);
+                event.preventDefault();
+              }}
+            >
+              <span>{layerVisibilityClassName !== 'fa fa-eye all-layers-handle' ?
+                t('LayerLegendAccordion.activateAllLayersText') :
+                t('LayerLegendAccordion.deactivateAllLayersText')}
+              </span>
+            </span> : null
+          }
           <LayerTree
             map={map}
             layerGroup={this._mapLayerGroup}

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.less
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.less
@@ -78,10 +78,9 @@
   }
 
   .base-layer-carousel,.topic-carousel {
-    .carousel {
-      height: 100%;
-      width: 100%;
-    }
+    background: rgba(darken(#4ba9ff, 5%), 75%);
+    border: 1px solid darken(#4ba9ff, 25%);
+    border-radius: 4px;
   }
 
   .topic-carousel {
@@ -94,10 +93,11 @@
 
   .base-layer-carousel {
     position: absolute;
-    top: calc(@layerset-basemap-chooser-height - 50%);
+    top: calc(@layerset-basemap-chooser-height - 42.5%);
     left: calc(@layerset-basemap-chooser-width - 87.5%);
-    height: 50%;
+    height: 42.5%;
     width: calc(@layerset-basemap-chooser-width - 12.5%);
   }
+
 }
 

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.less
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.less
@@ -1,0 +1,103 @@
+@layerset-basemap-chooser-width: 100vw;
+@layerset-basemap-chooser-height: 350px;
+
+.layerset-basemap-chooser {
+  position: absolute;
+  bottom: 35px;
+  left: 5px;
+
+  width: @layerset-basemap-chooser-width;
+  height: @layerset-basemap-chooser-height;
+
+  #overview-map {
+    position: absolute;
+    top: calc(@layerset-basemap-chooser-height - 42.5%);
+    left: 0;
+    height: 42.5%;
+    width: 10%;
+    display: flex;
+
+    .layerset-basemap-chooser-overviewmap {
+      flex: 1;
+      bottom: unset;
+      left: unset;
+      height: 100%;
+      width: 100%;
+
+      &.ol-control {
+        position: inherit;
+      }
+
+      .ol-overviewmap-map {
+        height: 100%;
+        width: 100%;
+        margin: 0;
+      }
+    }
+  }
+
+  .collapse-btn {
+    position: absolute;
+    top: calc(@layerset-basemap-chooser-height - 50%);
+    left: calc(@layerset-basemap-chooser-width - 90%);
+    height: 7.5%;
+    width: 2.5%;
+
+    align-self: end;
+    border: 1px solid darken(#4ba9ff, 25%);
+  }
+
+  .show-topic-carousel-toggle {
+    position: absolute;
+    top: calc(@layerset-basemap-chooser-height - 50%);
+    left: 0;
+    height: 7.5%;
+    width: 10%;
+    align-self: end;
+    border: 1px solid darken(#4ba9ff, 25%);
+  }
+
+  .show-baselayer-carousel-toggle {
+    position: absolute;
+    top: calc(@layerset-basemap-chooser-height - 42.5%);
+    left: calc(@layerset-basemap-chooser-width - 90%);
+    height: 42.5%;
+    width: 2.5%;
+
+    border: 1px solid darken(#4ba9ff, 25%);
+
+    div {
+      display: inline-block;
+      transform: rotate(-90deg);
+      margin: -40px;
+
+      .baselayer-carousel-toggle-text {
+        margin-left: 5px;
+      }
+    }
+  }
+
+  .base-layer-carousel,.topic-carousel {
+    .carousel {
+      height: 100%;
+      width: 100%;
+    }
+  }
+
+  .topic-carousel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 50%;
+    width: 100%;
+  }
+
+  .base-layer-carousel {
+    position: absolute;
+    top: calc(@layerset-basemap-chooser-height - 50%);
+    left: calc(@layerset-basemap-chooser-width - 87.5%);
+    height: 50%;
+    width: calc(@layerset-basemap-chooser-width - 12.5%);
+  }
+}
+

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.spec.tsx
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.spec.tsx
@@ -1,0 +1,33 @@
+/*eslint-env jest*/
+import TestUtils from '../../../spec/TestUtils';
+
+import LayerSetBaseMapChooser from './LayerSetBaseMapChooser';
+
+describe('<LayerSetBaseMapChooser />', () => {
+  let map;
+  let wrapper: any;
+
+  beforeEach(() => {
+    map = TestUtils.createMap({});
+    wrapper = TestUtils.mountComponent(LayerSetBaseMapChooser, {
+      t: () => {},
+      map: map,
+    }, {});
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    TestUtils.unmountMapDiv();
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(LayerSetBaseMapChooser).not.toBe(undefined);
+    });
+
+    it('can be rendered', () => {
+      expect(wrapper).not.toBe(undefined);
+    });
+  });
+
+});

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
@@ -7,6 +7,8 @@ import {
   SimpleButton
 } from '@terrestris/react-geo';
 
+import { isFunction } from 'lodash';
+
 import './LayerSetBaseMapChooser.less';
 import LayerCarousel from '../../component/LayerCarousel/LayerCarousel';
 
@@ -21,6 +23,7 @@ interface LayerSetBaseMapChooserProps extends Partial<DefaultLayerSetBaseMapChoo
   t: (arg: string) => {};
   baseLayerGroup: any;
   topicLayerGroup: any;
+  onTopicLayerGroupSelected: (arg: string) => void;
 }
 
 interface LayerSetBaseMapChooserState {
@@ -54,8 +57,8 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
     super(props);
 
     this.state = {
-      showTopicCarousel: true,
-      showBaseLayerCarousel: true
+      showTopicCarousel: false,
+      showBaseLayerCarousel: false
     }
 
     // binds
@@ -122,12 +125,19 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
   /**
    *
    */
-  onTopicLayerGroupSelected() {
+  onTopicLayerGroupSelected(layerOlUid: string) {
     this.setState({
       showTopicCarousel: false
     });
-    const { map } = this.props;
+    const {
+      map,
+      onTopicLayerGroupSelected
+    } = this.props;
     map.dispatchEvent('updateLayerAccordion');
+
+    if (isFunction(onTopicLayerGroupSelected)) {
+      onTopicLayerGroupSelected(layerOlUid);
+    }
   }
 
   /**

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+
+import OlOverviewMap from 'ol/control/OverviewMap';
+
+import {
+  ToggleButton,
+  SimpleButton
+} from '@terrestris/react-geo';
+
+import './LayerSetBaseMapChooser.less';
+import LayerCarousel from '../../component/LayerCarousel/LayerCarousel';
+
+// default props
+interface DefaultLayerSetBaseMapChooserProps {
+  loading: boolean;
+  onCollapse: (pressed: boolean) => void;
+}
+
+interface LayerSetBaseMapChooserProps extends Partial<DefaultLayerSetBaseMapChooserProps> {
+  map: any;
+  t: (arg: string) => {};
+  baseLayerGroup: any;
+  topicLayerGroup: any;
+}
+
+interface LayerSetBaseMapChooserState {
+  showBaseLayerCarousel: boolean;
+  showTopicCarousel: boolean;
+}
+
+/**
+ *
+ */
+class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps, LayerSetBaseMapChooserState> {
+
+  public static defaultProps: DefaultLayerSetBaseMapChooserProps = {
+    loading: false,
+    onCollapse: () => { }
+  };
+
+  /**
+   * Creates an instance of LayerSetBaseMapChooser.
+   * @param {LayerSetBaseMapChooserProps} props
+   * @memberof LayerSetBaseMapChooser
+   */
+  constructor(props: LayerSetBaseMapChooserProps) {
+    super(props);
+
+    this.state = {
+      showTopicCarousel: false,
+      showBaseLayerCarousel: false
+    }
+
+    // binds
+    this.onShowTopicCarouselToggle = this.onShowTopicCarouselToggle.bind(this);
+    this.onShowBaseLayerCarouselToggle = this.onShowBaseLayerCarouselToggle.bind(this);
+    this.onCollapseClick = this.onCollapseClick.bind(this);
+    this.onTopicLayerGroupSelected = this.onTopicLayerGroupSelected.bind(this);
+    this.onBaseLayerSelected = this.onBaseLayerSelected.bind(this);
+  }
+
+  /**
+   *
+   *
+   * @memberof LayerSetBaseMapChooser
+   */
+  componentDidMount() {
+    const {
+      map
+    } = this.props;
+
+    const overviewMap = new OlOverviewMap({
+      className: 'ol-overviewmap layerset-basemap-chooser-overviewmap',
+      collapsible: false,
+      collapsed: false,
+      target: document.getElementById('overview-map')
+    });
+
+    map.addControl(overviewMap);
+
+    // todo: check if DragRotateAndZoom is in map / activated
+    // interactions: ol.interaction.defaults().extend([
+    //   new ol.interaction.DragRotateAndZoom()
+    // ]),
+  }
+
+    /**
+   *
+   *
+   * @param {boolean} pressed
+   * @memberof SatAnalyseMain
+   */
+  onShowBaseLayerCarouselToggle(pressed: boolean) {
+    this.setState({
+      showBaseLayerCarousel: pressed
+    });
+  }
+
+    /**
+   *
+   *
+   * @param {boolean} pressed
+   * @memberof SatAnalyseMain
+   */
+  onShowTopicCarouselToggle(pressed: boolean) {
+    this.setState({
+      showTopicCarousel: pressed
+    });
+  }
+
+  /**
+   *
+   *
+   * @memberof LayerSetBaseMapChooser
+   */
+  onCollapseClick() {
+    this.props.onCollapse!(false);
+  }
+
+  /**
+   *
+   *
+   * @param {string} layerOlUid
+   * @memberof LayerSetBaseMapChooser
+   */
+  onTopicLayerGroupSelected(layerOlUid: string) {
+    this.setState({
+      showTopicCarousel: false
+    });
+    const { map} = this.props;
+    map.dispatchEvent('updateLayerAccordion');
+  }
+
+  /**
+   *
+   */
+  onBaseLayerSelected(layerOlUid: string) {
+    this.setState({
+      showBaseLayerCarousel: false
+    });
+    const { map } = this.props;
+    map.dispatchEvent('updateLayerAccordion');
+  }
+
+  /**
+   *
+   *
+   * @returns
+   * @memberof LayerSetBaseMapChooser
+   */
+  render() {
+    const {
+      baseLayerGroup,
+      map,
+      topicLayerGroup
+    } = this.props;
+
+    const {
+      showTopicCarousel,
+      showBaseLayerCarousel
+    } = this.state;
+
+    return (
+      <div className="layerset-basemap-chooser">
+       {
+        showTopicCarousel ?
+          <LayerCarousel
+            className="topic-carousel"
+            map={map}
+            layers={topicLayerGroup.getLayers().getArray()}
+            onLayerSelected={this.onTopicLayerGroupSelected}
+          /> : null
+        }
+        {
+          showBaseLayerCarousel ?
+            <LayerCarousel
+              className="base-layer-carousel"
+              map={map}
+              layers={baseLayerGroup.getLayers().getArray()}
+              onLayerSelected={this.onBaseLayerSelected}
+            /> : null
+        }
+        <div id="overview-map" />
+        <SimpleButton
+          size="small"
+          className="collapse-btn"
+          icon="compress"
+          onClick={this.onCollapseClick}
+        />
+        <ToggleButton
+          icon={showTopicCarousel ? 'angle-double-down' : 'angle-double-up'}
+          size="small"
+          className="show-topic-carousel-toggle"
+          pressed={showTopicCarousel}
+          onToggle={this.onShowTopicCarouselToggle}
+        >
+          Themen
+        </ToggleButton>
+        <ToggleButton
+          size="small"
+          className="show-baselayer-carousel-toggle"
+          pressed={showBaseLayerCarousel}
+          onToggle={this.onShowBaseLayerCarouselToggle}
+        >
+          <div>
+            <span className={showBaseLayerCarousel ? 'fa fa-angle-double-up' : 'fa fa-angle-double-down'} />
+            <span className="baselayer-carousel-toggle-text">Basiskarten</span>
+          </div>
+        </ToggleButton>
+        </div>
+    );
+  }
+}
+
+export default LayerSetBaseMapChooser;

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
@@ -33,6 +33,13 @@ interface LayerSetBaseMapChooserState {
  */
 class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps, LayerSetBaseMapChooserState> {
 
+  /**
+   * The default props of LayerSetBaseMapChooser
+   *
+   * @static
+   * @type {DefaultLayerSetBaseMapChooserProps}
+   * @memberof LayerSetBaseMapChooser
+   */
   public static defaultProps: DefaultLayerSetBaseMapChooserProps = {
     loading: false,
     onCollapse: () => { }
@@ -47,8 +54,8 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
     super(props);
 
     this.state = {
-      showTopicCarousel: false,
-      showBaseLayerCarousel: false
+      showTopicCarousel: true,
+      showBaseLayerCarousel: true
     }
 
     // binds
@@ -60,7 +67,7 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
   }
 
   /**
-   *
+   * After the compoment did mount, add the overviewmap to generated div
    *
    * @memberof LayerSetBaseMapChooser
    */
@@ -77,11 +84,6 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
     });
 
     map.addControl(overviewMap);
-
-    // todo: check if DragRotateAndZoom is in map / activated
-    // interactions: ol.interaction.defaults().extend([
-    //   new ol.interaction.DragRotateAndZoom()
-    // ]),
   }
 
     /**
@@ -119,22 +121,19 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
 
   /**
    *
-   *
-   * @param {string} layerOlUid
-   * @memberof LayerSetBaseMapChooser
    */
-  onTopicLayerGroupSelected(layerOlUid: string) {
+  onTopicLayerGroupSelected() {
     this.setState({
       showTopicCarousel: false
     });
-    const { map} = this.props;
+    const { map } = this.props;
     map.dispatchEvent('updateLayerAccordion');
   }
 
   /**
    *
    */
-  onBaseLayerSelected(layerOlUid: string) {
+  onBaseLayerSelected() {
     this.setState({
       showBaseLayerCarousel: false
     });

--- a/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
+++ b/packages/baseclient-components/src/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
@@ -161,7 +161,8 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
     const {
       baseLayerGroup,
       map,
-      topicLayerGroup
+      topicLayerGroup,
+      t
     } = this.props;
 
     const {
@@ -203,7 +204,7 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
           pressed={showTopicCarousel}
           onToggle={this.onShowTopicCarouselToggle}
         >
-          Themen
+          {t('LayerSetBaseMapChooser.topicText')}
         </ToggleButton>
         <ToggleButton
           size="small"
@@ -213,7 +214,7 @@ class LayerSetBaseMapChooser extends React.Component<LayerSetBaseMapChooserProps
         >
           <div>
             <span className={showBaseLayerCarousel ? 'fa fa-angle-double-up' : 'fa fa-angle-double-down'} />
-            <span className="baselayer-carousel-toggle-text">Basiskarten</span>
+            <span className="baselayer-carousel-toggle-text">{t('LayerSetBaseMapChooser.baseLayerText')}</span>
           </div>
         </ToggleButton>
         </div>

--- a/packages/baseclient-components/src/container/Legend/LegendContainer.tsx
+++ b/packages/baseclient-components/src/container/Legend/LegendContainer.tsx
@@ -61,18 +61,19 @@ export default class LegendContainer extends React.Component<LegendContainerProp
     if (filterFn) {
       layers = layers.filter(filterFn);
     }
-    
+
     // clone the array, reverse will work in place
     const reversed = layers.slice(0).reverse();
-
-    const legends = reversed.map((l: any) => {
-      return <Legend
-        key={l.ol_uid}
-        layer={l}
-        scale={scale}
-        collapsed={false}
-      />;
-    });
+    const legends = reversed.map((l: any) =>
+      (
+        <Legend
+          key={l.ol_uid}
+          layer={l}
+          scale={scale}
+          collapsed={false}
+        />
+      )
+    );
 
     return (
       <div>

--- a/packages/baseclient-components/src/container/PrintPanel/PrintPanelV3.tsx
+++ b/packages/baseclient-components/src/container/PrintPanel/PrintPanelV3.tsx
@@ -474,12 +474,14 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
   getOptionsForLegendSelect() {
     return this.getFilteredLegendLayers()
       .map((layer: any) =>
-        <Option
-          key={layer.ol_uid}
-          value={layer.ol_uid}
-        >
-          {layer.get('name')}
-        </Option>
+        (
+          <Option
+            key={layer.ol_uid}
+            value={layer.ol_uid}
+          >
+            {layer.get('name')}
+          </Option>
+        )
       );
   }
 

--- a/packages/baseclient-components/src/container/PrintPanel/PrintPanelV3.tsx
+++ b/packages/baseclient-components/src/container/PrintPanel/PrintPanelV3.tsx
@@ -17,6 +17,8 @@ import {
   Titlebar
 } from '@terrestris/react-geo';
 
+import OlLayerGroup from 'ol/layer/Group';
+
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 import { MapFishPrintV3Manager } from '@terrestris/mapfish-print-manager';
@@ -176,7 +178,7 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
       customPrintScales: this.getPrintScales(),
       timeout: 30000,
       legendFilter: (layer: any) => this.state.legendIds.includes(layer.ol_uid),
-      layerFilter: (layer: any) => !this.props.printLayerBlackList.includes(layer.get('name'))
+      layerFilter: (layer: any) => !(layer instanceof OlLayerGroup) && !this.props.printLayerBlackList.includes(layer.get('name'))
     });
 
     this.printManager = printManager;

--- a/packages/baseclient-components/src/util/PrintUtil/PrintUtil.js
+++ b/packages/baseclient-components/src/util/PrintUtil/PrintUtil.js
@@ -15,7 +15,7 @@ export class PrintUtil {
    * @return {Array} The printable layers.
    */
   static getPrintableLayers = (map, printLayer) => {
-    const layers = MapUtil.getAllLayers(map); //map.getLayers().getArray();
+    const layers = MapUtil.getAllLayers(map);
     return layers.filter(layer => {
       const layerName = layer.get('name');
       return layerName

--- a/packages/baseclient-components/src/util/PrintUtil/PrintUtil.js
+++ b/packages/baseclient-components/src/util/PrintUtil/PrintUtil.js
@@ -1,4 +1,6 @@
+import OlLayerGroup from 'ol/layer/Group';
 import StringUtil from '@terrestris/base-util/dist/StringUtil/StringUtil';
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 /**
  * Helper class for some operations related to print function.
@@ -13,12 +15,13 @@ export class PrintUtil {
    * @return {Array} The printable layers.
    */
   static getPrintableLayers = (map, printLayer) => {
-    const layers = map.getLayers().getArray();
+    const layers = MapUtil.getAllLayers(map); //map.getLayers().getArray();
     return layers.filter(layer => {
       const layerName = layer.get('name');
       return layerName
-        && (!layerName.includes('react-geo'))
+        && !(layerName.includes('react-geo'))
         && layer.getVisible()
+        && !(layer instanceof OlLayerGroup)
         && layer !== printLayer;
     });
   }

--- a/packages/baseclient/src/index.tsx
+++ b/packages/baseclient/src/index.tsx
@@ -77,14 +77,14 @@ const mapPromise = new Promise((resolve, reject) => {
       olProjection.setExtent(mapExtent);
     }
 
-    let mapView = new OlView({
+    const mapView = new OlView({
       center: center,
       zoom: zoom,
       projection: olProjection,
       resolutions: resolutions
     });
 
-    let map = new OlMap({
+    const map = new OlMap({
       view: mapView,
       keyboardEventTarget: document,
       controls: OlDefaultControls({

--- a/packages/baseclient/src/resources/i18n/de.json
+++ b/packages/baseclient/src/resources/i18n/de.json
@@ -11,6 +11,12 @@
     "line": "Linie",
     "area": "Fläche"
   },
+  "ZoomIn": {
+    "tooltip": "Hineinzoomen"
+  },
+  "ZoomOut": {
+    "tooltip": "Herauszoomen"
+  },
   "Imprint": {
     "title": "Impressum",
     "contact": "Kontakt",
@@ -59,10 +65,14 @@
   "LayerLegendAccordion": {
     "toggleVisibilityTooltipText": "Sichtbarkeit",
     "layerSettingsTooltipText": "Eigenschaften",
-    "collapseAccordionTooltipText": "Themenauswahl / Legende anzeigen",
-    "layerTreeTilte": "Themenauswahl",
+    "collapseAccordionTooltipText": "Layerliste / Legende anzeigen",
+    "layerTreeTilte": "Layerliste",
     "legendPanelTitle": "Legende",
     "activateAllLayersText": "Alle Layer aktivieren",
     "deactivateAllLayersText": "Alle Layer deaktivieren"
+  },
+  "LayerSetBaseMapChooser": {
+    "topicText": "Themen",
+    "baseLayerText": "Basiskarten"
   }
 }

--- a/packages/baseclient/src/resources/i18n/de.json
+++ b/packages/baseclient/src/resources/i18n/de.json
@@ -68,8 +68,8 @@
     "collapseAccordionTooltipText": "Layerliste / Legende anzeigen",
     "layerTreeTilte": "Layerliste",
     "legendPanelTitle": "Legende",
-    "activateAllLayersText": "Alle Layer aktivieren",
-    "deactivateAllLayersText": "Alle Layer deaktivieren"
+    "activateAllLayersText": "Alle Themenlayer aktivieren",
+    "deactivateAllLayersText": "Alle Themenlayer deaktivieren"
   },
   "LayerSetBaseMapChooser": {
     "topicText": "Themen",

--- a/packages/baseclient/src/resources/i18n/en.json
+++ b/packages/baseclient/src/resources/i18n/en.json
@@ -68,8 +68,8 @@
     "collapseAccordionTooltipText": "Show layer list / legend",
     "layerTreeTilte": "Layer list",
     "legendPanelTitle": "Legend",
-    "activateAllLayersText": "Activate all layers",
-    "deactivateAllLayersText": "De-activate all layers"
+    "activateAllLayersText": "Activate all topic layers",
+    "deactivateAllLayersText": "De-activate all topic layers"
   },
   "LayerSetBaseMapChooser": {
     "topicText": "Topics",

--- a/packages/baseclient/src/resources/i18n/en.json
+++ b/packages/baseclient/src/resources/i18n/en.json
@@ -11,6 +11,12 @@
     "line": "Line",
     "area": "Area"
   },
+  "ZoomIn": {
+    "tooltip": "Zoom in"
+  },
+  "ZoomOut": {
+    "tooltip": "Zoom out"
+  },
   "Imprint": {
     "title": "Imprint",
     "contact": "Contact",
@@ -59,10 +65,14 @@
   "LayerLegendAccordion": {
     "toggleVisibilityTooltipText": "Visibility",
     "layerSettingsTooltipText": "Properties",
-    "collapseAccordionTooltipText": "Show layertree / legend",
-    "layerTreeTilte": "Layertree",
+    "collapseAccordionTooltipText": "Show layer list / legend",
+    "layerTreeTilte": "Layer list",
     "legendPanelTitle": "Legend",
     "activateAllLayersText": "Activate all layers",
     "deactivateAllLayersText": "De-activate all layers"
+  },
+  "LayerSetBaseMapChooser": {
+    "topicText": "Topics",
+    "baseLayerText": "Base layers"
   }
 }

--- a/packages/baseclient/src/util/AppContextUtil.tsx
+++ b/packages/baseclient/src/util/AppContextUtil.tsx
@@ -169,7 +169,9 @@ class AppContextUtil {
       hoverable: layerObj.appearance.hoverable,
       hoverTemplate: layerObj.appearance.hoverTemplate,
       type: layerObj.source.type,
-      legendUrl: layerObj.appearance.legendUrl
+      legendUrl: layerObj.appearance.legendUrl,
+      isBaseLayer: layerObj.isBaseLayer,
+      topic: layerObj.topic
     });
   }
 
@@ -194,7 +196,9 @@ class AppContextUtil {
       hoverable: layerObj.appearance.hoverable,
       hoverTemplate: layerObj.appearance.hoverTemplate,
       type: layerObj.source.type,
-      legendUrl: layerObj.appearance.legendUrl
+      legendUrl: layerObj.appearance.legendUrl,
+      isBaseLayer: layerObj.isBaseLayer,
+      topic: layerObj.topic
     });
   }
 

--- a/packages/baseclient/src/util/AppContextUtil.tsx
+++ b/packages/baseclient/src/util/AppContextUtil.tsx
@@ -231,8 +231,8 @@ class AppContextUtil {
             type="primary"
             shape="circle"
             icon="plus"
-            tooltip={t('test')}
-            tooltipPlacement={'left'}
+            tooltip={t('ZoomIn.tooltip')}
+            tooltipPlacement={'right'}
           />);
           return;
         case 'basigx-button-zoomout':
@@ -243,6 +243,8 @@ class AppContextUtil {
             type="primary"
             shape="circle"
             icon="minus"
+            tooltip={t('ZoomOut.tooltip')}
+            tooltipPlacement={'right'}
           />);
           return;
         case 'shogun-button-zoomtoextent':

--- a/packages/baseclient/src/util/AppContextUtil.tsx
+++ b/packages/baseclient/src/util/AppContextUtil.tsx
@@ -157,7 +157,8 @@ class AppContextUtil {
       tileGrid: tileGrid,
       params: {
         'LAYERS': layerObj.source.layerNames,
-        'TILED': layerObj.source.requestWithTiled || false
+        'TILED': layerObj.source.requestWithTiled || false,
+        'TRANSPARENT': true
       }
     });
 
@@ -184,7 +185,8 @@ class AppContextUtil {
       url: layerObj.source.url,
       attributions: layerObj.appearance.attribution,
       params: {
-        'LAYERS': layerObj.source.layerNames
+        'LAYERS': layerObj.source.layerNames,
+        'TRANSPARENT': true
       }
     });
 


### PR DESCRIPTION
This PR introduces a new container `LayerSetBaseMapChooser` that combines an OpenLayers overview map with two carousels for choosing:
* *topics* :arrow_right: Set of layers that are assigned to a single group (in appContext this can be defined for a single layer using property `topic`)
* *base-layers* :arrow_right: Layer will be shown below all layers in the map  (in appContext this can be defined for a single layer using property `isBaseLayer`)

Herewith, it's needed that there exist at least an OpenLayers layer group for the base layer and the topic layers in the map. The base layer group contains all base layers and the topic layer group those of the currently active topic.

Please note, that the carousel component used in `LayerCarousel` had to switched to [`@brainhubeu/react-carousel`](https://github.com/brainhubeu/react-carousel) since antd carousel (and underlying component react-slick) has some drawbacks regarding layouting and calculation of slide widths.

![ScreenCapture](https://user-images.githubusercontent.com/10559603/58940863-ea68b000-877a-11e9-8b06-8eeb74df2023.gif)

Known issues:
* Thumbnails for topics are not configurable yet / can not be calculated automatically
* Currently only topic layers can be switched on/off with "global" switch

Deopends on https://github.com/terrestris/mapfish-print-manager/pull/173 and https://github.com/terrestris/mapfish-print-manager/pull/174

Please review @terrestris/devs 