### PR TITLE
Adds engines block to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,5 +165,9 @@
     "webpack-manifest-plugin": "^2.0.4",
     "whatwg-fetch": "^3.0.0",
     "winston": "^3.2.1"
+  },
+  "engines": {
+    "node": ">=10",
+    "npm": ">=5.6.0"
   }
 }


### PR DESCRIPTION
This adds an engines block to the `package.json`.

Configured with:
```
"node": ">=10",
"npm": ">=5.6.0"
```
These are the version used when using [nvm](https://github.com/nvm-sh/nvm) v10.0.0.