### PR TITLE
Restore alias pathes for some shared libraries

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -134,8 +134,16 @@ const commonWebpackConfig = {
     extensions: ['.ts', '.tsx', '.js'],
     modules: ['node_modules'],
     alias: {
-      // This is need if working with npm link
-      // 'ol': path.join(__dirname, '../node_modules', 'ol')
+       // This is need if working with npm link or while invoking react-geo-baseclient as submodule
+       // in some other project
+      '@terrestris/base-util': path.join(__dirname + '/../', 'node_modules', '@terrestris/base-util'),
+      '@terrestris/ol-util': path.join(__dirname + '/../', 'node_modules', '@terrestris/ol-util'),
+      '@terrestris/react-geo': path.join(__dirname + '/../', 'node_modules', '@terrestris/react-geo'),
+      'antd': path.join(__dirname + '/../', 'node_modules', 'antd'),
+      'react': path.join(__dirname + '/../', 'node_modules', 'react'),
+      'react-redux': path.join(__dirname + '/../', 'node_modules', 'react-redux'),
+      'react-i18next': path.join(__dirname + '/../', 'node_modules', 'react-i18next'),
+      'ol': path.join(__dirname + '/../', 'node_modules', 'ol')
     }
   }
 };


### PR DESCRIPTION
Restored some alias pathes previously removed during [lerna refactoring](https://github.com/terrestris/react-geo-baseclient/pull/448/files#diff-56ee2db4e3db0c7354bb996b003e70beL135) to prevent dublicated loading of packages.

Please review @terrestris/devs 