### PR TITLE
Configuration changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": ".",
   "scripts": {
     "start:static": "webpack-dev-server --config config/webpack.static.config.js --hot",
-    "start:shogun2": "env-cmd -f .shogunrc webpack-dev-server --config config/webpack.shogun2.config.js --hot",
+    "start:shogun2": "webpack-dev-server --config config/webpack.shogun2.config.js --hot",
     "build:static": "node scripts/build.js",
     "build:shogun2": "node scripts/build.js",
     "test": "node scripts/test.js --config config/jest/jest.config.js --runInBand --no-colors",


### PR DESCRIPTION
Configuration changed in order to start the baseclient with a project .shogunrc
Otherwise the project rc would be overwritten with the defaults given in the react-geo-baseclient .shogunrc

```
  "scripts": {
...
    "start": "cd ../react-geo-baseclient/ && env-cmd -f ../react-client/.shogunrc npm run start:shogun2",
...
  },
```

Please review @terrestris/devs 