### PR TITLE
Fix multiple projection handling

### DIFF
--- a/src/state/actions/MapViewChangeAction.spec.ts
+++ b/src/state/actions/MapViewChangeAction.spec.ts
@@ -1,7 +1,7 @@
 /*eslint-env jest*/
 import * as actions from './MapViewChangeAction';
 import {
-  SET_MAPVIEW,
+  SET_PROJECTION,
   SET_CENTER,
   SET_ZOOM,
   SET_SCALE,
@@ -9,20 +9,7 @@ import {
   ZOOM_OUT
 } from '../constants/MapViewChange';
 
-const mapView = {
-  center: [370000, 5546750],
-  zoom: 0
-};
-
 describe('MapViewChangeAction', () => {
-
-  it ('dispatches an action on map view change', () => {
-    const expectedAction = {
-      type: SET_MAPVIEW,
-      mapView
-    };
-    expect(actions.setMapView(mapView)).toEqual(expectedAction);
-  });
 
   it ('dispatches an action on center change', () => {
     const expectedAction = {
@@ -38,6 +25,14 @@ describe('MapViewChangeAction', () => {
       zoom: 9
     };
     expect(actions.setZoom(9)).toEqual(expectedAction);
+  });
+
+  it('dispatches an action on projection change', () => {
+    const expectedAction = {
+      type: SET_PROJECTION,
+      projection: 'EPSG:4326'
+    };
+    expect(actions.setProjection('EPSG:4326')).toEqual(expectedAction);
   });
 
   it ('dispatches an action on setting map scale', () => {

--- a/src/state/actions/MapViewChangeAction.ts
+++ b/src/state/actions/MapViewChangeAction.ts
@@ -1,25 +1,12 @@
 import {
   SET_CENTER,
-  SET_MAPVIEW,
+  SET_PROJECTION,
   SET_SCALE,
   SET_ZOOM,
   ZOOM_IN,
   ZOOM_OUT
 } from '../constants/MapViewChange';
 
-/**
- * setMapView - action
- *
- * @param {Object} mapView the mapview having center and zoom property
- *
- * @return {Object} setMapView action object
- */
-export function setMapView(mapView: any) {
-  return {
-    type: SET_MAPVIEW,
-    mapView
-  };
-}
 
 /**
  * setCenter - action
@@ -32,6 +19,20 @@ export function setCenter(center: number[]) {
   return {
     type: SET_CENTER,
     center: center
+  };
+}
+
+/**
+ * setProjection - action
+ *
+ * @param {string} code projection code of the map
+ *
+ * @return {Object} setProjection action object
+ */
+export function setProjection(code: string) {
+  return {
+    type: SET_PROJECTION,
+    projection: code
   };
 }
 

--- a/src/state/constants/MapViewChange.ts
+++ b/src/state/constants/MapViewChange.ts
@@ -1,6 +1,6 @@
 export const SET_CENTER = 'SET_CENTER';
 export const SET_ZOOM = 'SET_ZOOM';
+export const SET_PROJECTION = 'SET_PROJECTION';
 export const ZOOM_IN = 'ZOOM_IN';
 export const ZOOM_OUT = 'ZOOM_OUT';
-export const SET_MAPVIEW = 'SET_MAPVIEW';
 export const SET_SCALE = 'SET_SCALE';

--- a/src/state/reducers/MapViewReducer.spec.ts
+++ b/src/state/reducers/MapViewReducer.spec.ts
@@ -1,7 +1,7 @@
 /*eslint-env jest*/
 import { reduce } from './MapViewReducer';
 import {
-  SET_MAPVIEW,
+  SET_PROJECTION,
   SET_CENTER,
   SET_ZOOM,
   SET_SCALE,
@@ -15,33 +15,25 @@ describe('MapViewReducer', () => {
     expect(reduce(undefined, {})).toEqual({});
   });
 
-  it('should handle SET_MAPVIEW', () => {
+  it('should handle SET_PROJECTION', () => {
     // test with empty initial state
     const mapViewState = {
-      center: [0, 0],
-      zoom: 9
+      projection: 'EPSG:4326'
     };
     const defaultAction = {
-      type: SET_MAPVIEW,
-      mapView: {
-        center: [0, 0],
-        zoom: 9
-      }
+      type: SET_PROJECTION,
+      projection: 'EPSG:4326'
     };
+
     expect(reduce({}, defaultAction)).toEqual(mapViewState);
 
     // test with existing state
     const actionChangedView = {
-      type: SET_MAPVIEW,
-      mapView: {
-        center: [19, 19],
-        zoom: 19
-      }
+      type: SET_PROJECTION,
+      projection: 'EPSG:3857'
     };
-
     expect(reduce(mapViewState, actionChangedView)).toEqual({
-      center: [19, 19],
-      zoom: 19
+      projection: 'EPSG:3857'
     });
   });
 

--- a/src/state/reducers/MapViewReducer.ts
+++ b/src/state/reducers/MapViewReducer.ts
@@ -5,8 +5,8 @@ import { MapUtil } from '@terrestris/ol-util/src/MapUtil/MapUtil';
 import {
   SET_CENTER,
   SET_ZOOM,
+  SET_PROJECTION,
   SET_SCALE,
-  SET_MAPVIEW,
   ZOOM_IN,
   ZOOM_OUT
 } from '../constants/MapViewChange';
@@ -25,6 +25,10 @@ export function reduce(mapViewState = initialState, action: any) {
     case SET_ZOOM:
       return Object.assign({}, mapViewState, {
         zoom: action.zoom
+      });
+    case SET_PROJECTION:
+      return Object.assign({}, mapViewState, {
+        projection: action.projection
       });
     case SET_SCALE:
       return Object.assign({}, mapViewState, {
@@ -47,11 +51,6 @@ export function reduce(mapViewState = initialState, action: any) {
           : ((mapViewState.zoom - 1) >= 0
             ? mapViewState.zoom - 1
             : 0)
-      });
-    case SET_MAPVIEW:
-      return Object.assign({}, mapViewState, {
-        center: action.mapView.center,
-        zoom: action.mapView.zoom
       });
     default:
       return mapViewState;


### PR DESCRIPTION
Fix application behaviour on CRS change:
* Ensure that chosen CRS will be properly set on map
* Set updated resolutions on reprojected view
* Store updated CRS value in global state to stay in sync with all app components on CRS change

Additionally got rid of `SET_MAPVIEW` action by replacing it with more precise isolated actions setting only affected parameter.

PR has to be rebased after https://github.com/terrestris/react-geo-baseclient/pull/462 is in.

Please review @KaiVolland 