### PR TITLE
Reenable puppeteer tests

### DIFF
--- a/src/App.spec.js
+++ b/src/App.spec.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jest-environment-puppeteer
+ */
 describe('Application render', () => {
   let page;
   let getMapFound = false;


### PR DESCRIPTION
jest-puppeteer tests were not running as it was not picked up by the config anymore.
This enables it again by renaming the file.

@KaiVolland please review