### PR TITLE
Use `Map` component in main project class

### DIFF
--- a/src/ProjectMain.tsx
+++ b/src/ProjectMain.tsx
@@ -6,7 +6,7 @@ import i18n from './i18n';
 import BrowserUtil from './util/BrowserUtil';
 import SomethingWentWrong from './SomethingWentWrong';
 
-import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import Map from './component/Map/Map';
 import Toolbar from '@terrestris/react-geo/dist/Toolbar/Toolbar';
 
 import AppContextUtil from './util/AppContextUtil';
@@ -113,7 +113,7 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
             collapsible={false}
             measureToolsEnabled={measureToolsEnabled}
           />
-          <MapComponent
+          <Map
             map={map}
           />
           <Toolbar

--- a/src/component/Map/Map.tsx
+++ b/src/component/Map/Map.tsx
@@ -34,7 +34,7 @@ interface DefaultMapProps {
 
 interface MapProps extends Partial<DefaultMapProps> {
   map: any, //OlMap
-  children: Element,
+  children?: Element,
   dispatch: (arg: any) => void,
   center: number[],
   zoom: number,


### PR DESCRIPTION
Using of `Map` component allows listening to some custom map events, inter alia `change:view`, which is responsible for setting of proper map projection into global state.

Fixes #466.

Please review @weskamm 