### PR TITLE
Make sider collapsible per default

### DIFF
--- a/src/ProjectMain.tsx
+++ b/src/ProjectMain.tsx
@@ -110,7 +110,6 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
             map={map}
             t={t}
             i18n={i18n}
-            collapsible={false}
             measureToolsEnabled={measureToolsEnabled}
           />
           <MapComponent

--- a/src/component/SiderMenu/SiderMenu.tsx
+++ b/src/component/SiderMenu/SiderMenu.tsx
@@ -12,9 +12,12 @@ const { Sider } = Layout;
 const SubMenu = Menu.SubMenu;
 
 // default props
-interface SiderProps {
+interface DefaultSiderProps {
+  collapsible?: boolean
+}
+
+interface SiderProps extends Partial<DefaultSiderProps> {
   collapsed?: boolean,
-  collapsible?: boolean,
   map: any,
   t: (arg: string) => {},
   i18n: any,
@@ -32,6 +35,13 @@ interface SiderState {
  * @extends React.Component
  */
 export class SiderMenu extends React.Component<SiderProps, SiderState> {
+
+  /**
+  * The default properties.
+  */
+  public static defaultProps: DefaultSiderProps = {
+    collapsible: true
+  };
 
   /**
    * Create a SiderMenu component.


### PR DESCRIPTION
Reenables `collapsible` mode of sider. 

Additionally makes `Sider` component collabsible per default, so no custom config needed any more.

Addresses #465.

Please review @weskamm 