### PR TITLE
Introduce measure menu toolbar

### DIFF
--- a/src/component/button/MeasureMenuButton/MeasureMenuButton.less
+++ b/src/component/button/MeasureMenuButton/MeasureMenuButton.less
@@ -1,0 +1,13 @@
+.measure-tools-wrapper {
+  position: relative;
+
+  .measure-tb {
+    position: absolute;
+    top: 0;
+    width: 110px;
+    left: 45px;
+    .react-geo-togglegroup {
+      width: 100%;
+    }
+  }
+}

--- a/src/component/button/MeasureMenuButton/MeasureMenuButton.tsx
+++ b/src/component/button/MeasureMenuButton/MeasureMenuButton.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+
+import MeasureButton from '@terrestris/react-geo/dist/Button/MeasureButton/MeasureButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import Toolbar from '@terrestris/react-geo/dist/Toolbar/Toolbar';
+import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';
+
+import { Menu } from 'antd';
+
+import './MeasureMenuButton.less';
+
+interface DefaultMeasureMenuButtonProps {
+  type: string,
+  shape: string,
+  menuPlacement: any
+}
+
+interface MeasureMenuButtonProps extends Partial<DefaultMeasureMenuButtonProps> {
+  map: any,
+  tooltip: string,
+  measureTypes: string [],
+  key: string,
+  t: (arg: string) => string
+}
+
+interface MeasureMenuButtonState {
+  showToolbar: boolean,
+  activeTool: string,
+  activeToolIcon: string
+}
+
+/**
+ * Class representing the MeasureMenuButton.
+ *
+ * @class MeasureMenuButton
+ * @extends React.Component
+ */
+export default class MeasureMenuButton extends React.Component<MeasureMenuButtonProps, MeasureMenuButtonState> {
+
+  /**
+  * The default properties.
+  */
+  public static defaultProps: DefaultMeasureMenuButtonProps = {
+    type: 'primary',
+    shape: 'circle',
+    menuPlacement: 'bottomRight'
+  };
+
+  /**
+   * Create the MeasureMenuButton.
+   *
+   * @constructs MeasureMenuButton
+   */
+  constructor(props: MeasureMenuButtonProps) {
+    super(props);
+
+    this.state = {
+      showToolbar: false,
+      activeTool: null,
+      activeToolIcon: 'print' // TODO
+    }
+
+    this.getToolbarItems = this.getToolbarItems.bind(this);
+    this.onToggledToolChange = this.onToggledToolChange.bind(this);
+    this.onMenuButtonClick = this.onMenuButtonClick.bind(this);
+  }
+
+  /**
+   *
+   * @param measureType
+   */
+  getButtonIcon(measureType: string) {
+    // TODO set meaningful icons
+    switch (measureType) {
+      case 'line':
+        return 'print';
+      case 'polygon':
+        return 'info';
+      case 'angle':
+        return 'globe';
+      default:
+        break;
+    }
+  }
+
+  /**
+   *
+   */
+  getMenuItems() {
+    const {
+      measureTypes,
+      map,
+      type,
+      shape
+    } = this.props;
+
+    return (
+      <Menu>
+        {
+          measureTypes.map((mt: string) => {
+            const icon = this.getButtonIcon(mt);
+            return <Menu.Item key={mt}>
+              <MeasureButton
+                type={type}
+                shape={shape}
+                icon={icon}
+                map={map}
+                measureType={mt}
+              />
+            </Menu.Item>
+          })
+        }
+      </Menu>
+    );
+  }
+
+  /**
+   *
+   */
+  onMenuButtonClick() {
+    this.setState({
+      showToolbar: !this.state.showToolbar
+    });
+  }
+
+  /**
+   *
+   */
+  onToggledToolChange(button: any) {
+    const pressed = !button.pressed;
+      this.setState({
+        activeTool: pressed ? button.name : null,
+        activeToolIcon: pressed ? button.icon : 'print' // TODO adapt icons
+      });
+  }
+
+  /**
+   *
+   */
+  getToolbarItems() {
+    const {
+      measureTypes,
+      map,
+      type,
+      shape
+    } = this.props;
+
+    const {
+      activeTool
+    } = this.state;
+
+    return (
+      <ToggleGroup
+        orientation="horizontal"
+        selectedName={activeTool}
+        onChange={this.onToggledToolChange}
+      >
+        {
+          measureTypes.map((mt: string) => {
+            const icon = this.getButtonIcon(mt);
+            return <MeasureButton
+              key={mt}
+              name={mt}
+              type={type}
+              shape={shape}
+              icon={icon}
+              map={map}
+              pressed={activeTool === mt}
+              measureType={mt}
+            />
+          })
+        }
+      </ToggleGroup>
+    );
+  }
+
+  /**
+   * The render function
+   */
+  render() {
+    const {
+      type,
+      shape
+    } = this.props;
+
+    const {
+      showToolbar,
+      activeToolIcon
+    } = this.state;
+
+    return (
+      <div
+        className="measure-tools-wrapper"
+      >
+        <SimpleButton
+          type={type}
+          shape={shape}
+          icon={activeToolIcon}
+          onClick={this.onMenuButtonClick}
+        />
+        {
+          showToolbar &&
+          <Toolbar
+            className="measure-tb"
+          >
+            {this.getToolbarItems()}
+          </Toolbar>
+        }
+      </div>
+    );
+  }
+}

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -23,10 +23,12 @@ import initialState from '../state/initialState';
 import getOSMLayer from '@terrestris/vectortiles';
 
 import PrintButton from '../component/button/PrintButton/PrintButton';
+import MeasureMenuButton from '../component/button/MeasureMenuButton/MeasureMenuButton';
 import HsiButton from '../component/button/HsiButton/HsiButton';
 
 import ZoomButton from '@terrestris/react-geo/dist/Button/ZoomButton/ZoomButton';
 import ZoomToExtentButton from '@terrestris/react-geo/dist/Button/ZoomToExtentButton/ZoomToExtentButton';
+import MeasureButton from '@terrestris/react-geo/dist/Button/MeasureButton/MeasureButton';
 
 /**
  * This class provides some static methods which can be used with the appContext of SHOGun2.
@@ -278,7 +280,6 @@ class AppContextUtil {
    * TODO: Missing features:
    * "shogun-button-stepback",
    * "shogun-button-stepforward",
-   * "shogun-button-showmeasuretoolspanel"
    * "shogun-button-showredliningtoolspanel"
    * "shogun-button-showworkstatetoolspanel"
    * "shogun-button-addwms"
@@ -355,6 +356,28 @@ class AppContextUtil {
             tooltipPlacement={'right'}
             t={t}
           />);
+          return;
+        case 'shogun-button-measure-menu':
+          if (module.properties.measureTypes.length === 1) {
+            tools.push(<MeasureButton
+              map={map}
+              measureType={module.properties.measureTypes[0]}
+              key="6"
+              tooltip={t('FeatureInfo.tooltip')}
+              tooltipPlacement={'right'}
+              showMeasureInfoOnClickedPoints={true}
+            />);
+          } else {
+            tools.push(<MeasureMenuButton
+              type="primary"
+              shape="circle"
+              map={map}
+              measureTypes={module.properties.measureTypes}
+              key="6"
+              tooltip={t('FeatureInfo.tooltip')}
+              t={t}
+            />);
+          }
           return;
         default:
           return;


### PR DESCRIPTION
Introduces collapsible measure menu toolbar which contains configured measure tools provided via props

![image](https://user-images.githubusercontent.com/3939355/60649887-44749800-9e43-11e9-8133-81bcae84d640.png)


TODOs:
* Toggle behaviour of parent button is still buggy (ol draw controls won't be deactivated clear on toolbar hiding)
* Icons for singly tools are missing
* Toolbar position (e.g. left or right from parent menu button) is not supported yet, currently toolbar will always be shown right to menu button

This PR will be used as start point for further development.

@KaiVolland :hand: 