### PR TITLE
Reflect map projection and map base layer changes on overview map

### DIFF
--- a/src/component/LayerCarouselSlide/LayerCarouselSlide.less
+++ b/src/component/LayerCarouselSlide/LayerCarouselSlide.less
@@ -1,3 +1,5 @@
+
+@main-component-color: #4ba9ff;
 .BrainhubCarouselItem {
   text-align: center;
   border: 1px solid white;
@@ -19,12 +21,12 @@
     margin: 5px 10px 10px 10px;
     max-width: 95%;
     box-sizing: content-box;
-    box-shadow: 0 0 10px 5px darken(#4ba9ff, 15%);
+    box-shadow: 0 0 10px 5px darken(@main-component-color, 15%);
     background: white;
     cursor: pointer;
   }
 
   .title-div {
-    background-color: lighten(#4ba9ff, 25%);
+    background-color: lighten(@main-component-color, 25%);
   }
 }

--- a/src/component/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.less
+++ b/src/component/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.less
@@ -1,3 +1,5 @@
+@main-component-color: #4ba9ff;
+
 .layerset-basemap-chooser {
   display: inline-grid;
   width: 100%;
@@ -29,34 +31,37 @@
         width: 200px;
         height: 200px;
       }
+      .ol-overviewmap-box {
+        border: 2px solid darken(@main-component-color, 25%);
+      }
     }
   }
 
   .collapse-btn {
     grid-column: 2;
     grid-row: 2;
-    border: 1px solid darken(#4ba9ff, 25%);
+    border: 1px solid darken(@main-component-color, 25%);
     border-radius: 0 4px 0 0;
   }
 
   .show-topic-carousel-toggle {
     grid-column: 1;
     grid-row: 2;
-    border: 1px solid darken(#4ba9ff, 25%);
+    border: 1px solid darken(@main-component-color, 25%);
   }
 
   .show-baselayer-carousel-toggle {
     grid-column: 2;
     grid-row: 3;
-    border: 1px solid darken(#4ba9ff, 25%);
+    border: 1px solid darken(@main-component-color, 25%);
     >div {
       transform: rotate(-90deg) translate(-20px, 0px);
     }
   }
 
   .base-layer-carousel, .topic-carousel {
-    background: rgba(darken(#4ba9ff, 5%), 75%);
-    border: 1px solid darken(#4ba9ff, 25%);
+    background: rgba(darken(@main-component-color, 5%), 75%);
+    border: 1px solid darken(@main-component-color, 25%);
   }
 
   .topic-carousel {


### PR DESCRIPTION
This PR contains fixes for the following overview map issues:
* Ensure that overview map will be shown on map projection change by passing the new view with the changed projection
* Set proper layers on overview map if map base layer was changed via `LayerSetBaseMapChooser` component.

Additionally extracted some repetetive color values to less variable.

Please review @terrestris/devs 