### PR TITLE
Time slider component refactoring

### DIFF
--- a/config/jest/spec/initialState.js
+++ b/config/jest/spec/initialState.js
@@ -1,15 +1,18 @@
+import moment from 'moment';
+
 export default {
   mapView: {
     present: {
-      center: [370000, 5546750],
+      center: [0, 0],
       zoom: 0,
       projection: 'EPSG:3857',
-      resolutions: [560, 280, 140, 70, 28, 14, 7, 2.8, 1.4, 0.7, 0.28, 0.14, 0.028],
-      mapExtent: [-20026376.39, -20048966.1, 20026376.39, 20048966.1]
+      resolutions: [],
+      mapExtent: []
     },
     past: [],
     future: []
   },
+  mapScales: [],
   appInfo: {
     name: 'React-geo baseclient',
     versionNumber: '0.1 (dev)'
@@ -24,5 +27,12 @@ export default {
   hoverFeatures: {
     isFetching: false,
     features: {}
+  },
+  appState: {
+    addLayerWindowVisible: false
+  },
+  dataRange: {
+    startDate: moment(moment.now()).subtract(1, 'days'),
+    endDate: moment(moment.now()).add(1, 'days')
   }
 };

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.less
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.less
@@ -21,9 +21,9 @@
     }
   }
 
-  .timeslider-in-future {
+  :not(.timeslider-in-future) {
     .ant-slider-handle {
-      background-color: #FFFFFF;
+      background-color: #4baeff;
     }
   }
 

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.less
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.less
@@ -44,4 +44,17 @@
     padding: 0 10px;
     font-weight: bold;
   }
+
+  &.no-layers-available {
+    pointer-events: none;
+    opacity: .8;
+    color: rgba(0, 0, 0, 0.35);
+    .ant-slider-mark span,
+    .ant-select {
+     color: rgba(0, 0, 0, 0.35);
+    }
+    button {
+      opacity: .5;
+    }
+  }
 }

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.less
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.less
@@ -40,7 +40,7 @@
 
   .time-value {
     text-align: center;
-    width: 90px;
+    width: 100px;
     padding: 0 10px;
     font-weight: bold;
   }

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.spec.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.spec.tsx
@@ -9,10 +9,12 @@ describe('<TimeLayerSliderPanel />', () => {
 
   beforeEach(() => {
     map = TestUtils.createMap({});
-    wrapper = TestUtils.mountComponent(TimeLayerSliderPanel, {
+    const defaultProps = {
       t: () => { },
       map: map,
-    }, {});
+      dispatch: jest.fn()
+    };
+    wrapper = TestUtils.shallowConnectedComponentRoot(TimeLayerSliderPanel, defaultProps, null);
   });
 
   afterEach(() => {

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -353,7 +353,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     };
 
     return (
-      <div className={`time-layer-slider ${disabledCls}`}>
+      <div className={`time-layer-slider ${disabledCls}`.trim()}>
 
         <Popover
           placement="topRight"
@@ -382,7 +382,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
             /> : null
         }
         <this._TimeLayerAwareSlider
-          className={extraCls + ' timeslider' + futureClass}
+          className={`${extraCls} timeslider ${futureClass}`.trim()}
           formatString={dateFormat}
           defaultValue={startDateString}
           min={startDateString}

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -255,12 +255,11 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
         }
 
         let newValue;
-        if (_isFinite(playbackSpeed)) {
+        if (_isFinite(parseFloat(playbackSpeed))) {
           newValue = value.clone().add(playbackSpeed, 'seconds');
         } else {
           newValue = value.clone().add(1, playbackSpeed as moment.DurationInputArg2);
         }
-
         this.timeSliderCustomHandler(newValue);
         this.wmsTimeHandler(newValue);
         // value is handled in timeSliderCustomHandler

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -115,6 +115,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   }
 
   componentDidUpdate(prevProps: TimeLayerSliderPanelProps) {
+    // TODO this deep check may impact performance..
     if (!(_isEqual(prevProps.timeAwareLayers, this.props.timeAwareLayers))) {
       // update slider properties if some another layer set was chosen
       this.wrapTimeSlider();

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -123,6 +123,40 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   }
 
   /**
+   *
+   * @param nextProps
+   * @param nextState
+   */
+  shouldComponentUpdate(nextProps: TimeLayerSliderPanelProps, nextState: TimeLayerSliderPanelState) {
+    const {
+      value,
+      autoPlayActive
+    } = this.state;
+    const {
+      startDate,
+      endDate,
+      timeAwareLayers
+    } = this.props;
+
+    if (nextState.value !== value) {
+      return true;
+    }
+    if (nextState.autoPlayActive !== autoPlayActive) {
+      return true;
+    }
+    if (nextProps.startDate !== startDate) {
+      return true;
+    }
+    if (nextProps.endDate !== endDate) {
+      return true;
+    }
+    if (!(_isEqual(nextProps.timeAwareLayers, timeAwareLayers))) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
   * Wraps the TimeSlider component in timeLayerAware.
   */
   wrapTimeSlider = () => {

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -113,10 +113,9 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   }
 
   componentDidUpdate(prevProps: TimeLayerSliderPanelProps) {
-    this.wrapTimeSlider();
-
-    // update range for slider if some another layer set was chosen
     if (!(_isEqual(prevProps.timeAwareLayers, this.props.timeAwareLayers))) {
+      // update slider properties if some another layer set was chosen
+      this.wrapTimeSlider();
       this.findRangeForLayers();
     }
   }
@@ -300,10 +299,10 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   */
   onTimeChanged(val: string) {
     this.setState({
-      value: moment(val)
+      value: moment(val).clone()
     }, () => {
       this.wmsTimeHandler(this.state.value);
-    })
+    });
   }
 
   /**

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -372,7 +372,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
 
         <Popover
           placement="topRight"
-          title="Zeitleisten Bereich"
+          title={t('TimeLayerSliderPanel.dataRange')}
           trigger="click"
           content={
             <RangePicker

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -349,7 +349,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   */
   onTimeChanged(val: string) {
     this.setState({
-      value: moment(val).clone()
+      value: moment(val)
     }, () => {
       this.wmsTimeHandler(this.state.value);
     });

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -50,6 +50,7 @@ export interface TimeLayerSliderPanelState {
   value: moment.Moment;
   playbackSpeed: string;
   autoPlayActive: boolean;
+  dateFormat: string;
 };
 
 /**
@@ -99,7 +100,8 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     this.state = {
       value: props.value,
       playbackSpeed: '1',
-      autoPlayActive: false
+      autoPlayActive: false,
+      dateFormat: props.dateFormat
     };
 
     this._interval = 1000;
@@ -125,16 +127,26 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   */
   wrapTimeSlider = () => {
     this._wmsTimeLayers = [];
+    let dateFormat: string;
     this.props.timeAwareLayers!.forEach((l: any) => {
       if (l.get('type') === 'WMSTime') {
         this._wmsTimeLayers.push({
           layer: l
         });
+        if (!dateFormat && l.get('timeFormat')) {
+          dateFormat = l.get('timeFormat');
+        }
       }
     });
     // make sure an initial value is set
     this.wmsTimeHandler(this.state.value);
     this._TimeLayerAwareSlider = timeLayerAware(TimeSlider, this._wmsTimeLayers);
+    // update date format
+    if (dateFormat) {
+      this.setState({
+        dateFormat
+      });
+    }
   }
 
   /**
@@ -314,7 +326,6 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     const {
       className,
       t,
-      dateFormat,
       startDate,
       endDate,
       timeAwareLayers
@@ -322,7 +333,8 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
 
     const {
       autoPlayActive,
-      value
+      value,
+      dateFormat
     } = this.state;
 
     const resetVisible = true;
@@ -391,7 +403,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
           onChange={this.onTimeChanged}
         />
         <div className="time-value">
-          {value.format('DD.MM.YYYY HH:mm:ss')}
+          {value.format(dateFormat)}
         </div>
         <ToggleButton
           type="primary"

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -317,6 +317,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
         <Popover
           placement="topRight"
           title="Zeitleisten Bereich"
+          trigger="click"
           content={
             <RangePicker
               showTime={{ format: 'HH:mm' }}

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -277,6 +277,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
       dateFormat,
       startDate,
       endDate,
+      timeAwareLayers
     } = this.props;
 
     const {
@@ -293,6 +294,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     const marks = {};
     const futureClass = moment().isBefore(value) ? ' timeslider-in-future' : '';
     const extraCls = className ? className : '';
+    const disabledCls = timeAwareLayers.length < 1 ? 'no-layers-available' : '';
 
     marks[startDateString] = {
       label: startDate!.format(dateFormat)
@@ -310,7 +312,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     };
 
     return (
-      <div className="time-layer-slider">
+      <div className={`time-layer-slider ${disabledCls}`}>
 
         <Popover
           placement="topRight"

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -169,20 +169,25 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     let endDatesFromLayers: moment.Moment[] = [];
 
     this._wmsTimeLayers.forEach((l: any) => {
-      const sd = moment(l.layer.get('startDate'));
-      const ed = moment(l.layer.get('endDate'));
-      if (sd) {
-        startDatesFromLayers.push(sd);
+      const startDate = l.layer.get('startDate');
+      const endDate = l.layer.get('endDate');
+      let sdm;
+      let edm;
+      if (startDate) {
+        sdm = moment(l.layer.get('startDate'));
       }
-      if (ed) {
-        endDatesFromLayers.push(ed);
+      if (endDate) {
+        edm = moment(l.layer.get('endDate'));
       }
-      newStartDate = moment.min([sd, startDate]);
-      newEndDate = moment.min([ed, endDate]);
-
+      if (sdm) {
+        startDatesFromLayers.push(sdm);
+      }
+      if (edm) {
+        endDatesFromLayers.push(edm);
+      }
     });
-    newStartDate = moment.min(startDatesFromLayers) || startDate;
-    newEndDate = moment.max(endDatesFromLayers) || endDate;
+    newStartDate = startDatesFromLayers.length > 0 ? moment.min(startDatesFromLayers) : startDate;
+    newEndDate = endDatesFromLayers.length > 0 ? moment.max(endDatesFromLayers) : endDate;
     this.updateDataRange([newStartDate, newEndDate]);
   }
 

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -407,7 +407,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
           onChange={this.onTimeChanged}
         />
         <div className="time-value">
-          {value.format(dateFormat)}
+          {value.format('DD.MM.YYYY HH:mm:ss')}
         </div>
         <ToggleButton
           type="primary"

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -99,7 +99,8 @@
     "days": "Tage",
     "weeks": "Wochen",
     "months": "Monate",
-    "years": "Jahre"
+    "years": "Jahre",
+    "dataRange": "Zeitraum auswählen"
   }
 }
 

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -99,6 +99,7 @@
     "days": "Days",
     "weeks": "Weeks",
     "months": "Months",
-    "years": "Years"
+    "years": "Years",
+    "dataRange": "Set data range"
   }
 }

--- a/src/state/actions/DataRangeAction.spec.ts
+++ b/src/state/actions/DataRangeAction.spec.ts
@@ -1,0 +1,29 @@
+/*eslint-env jest*/
+import * as actions from './DataRangeAction';
+import moment from 'moment';
+import {
+  SET_START_DATE,
+  SET_END_DATE
+} from '../constants/DataRange';
+
+
+describe('DataRangeAction', () => {
+
+  it('it should dispatch an action on start date change', () => {
+    const startDate = moment(moment.now());
+    const expectedAction = {
+      type: SET_START_DATE,
+      startDate
+    };
+    expect(actions.setStartDate(startDate)).toEqual(expectedAction);
+  });
+
+  it('it should dispatch an action on end date change', () => {
+    const endDate = moment(moment.now());
+    const expectedAction = {
+      type: SET_END_DATE,
+      endDate
+    };
+    expect(actions.setEndDate(endDate)).toEqual(expectedAction);
+  });
+});

--- a/src/state/actions/DataRangeAction.ts
+++ b/src/state/actions/DataRangeAction.ts
@@ -8,24 +8,24 @@ import {
 /**
  * Sets the set startDate value
  *
- * @param {moment.Moment} date
+ * @param {moment.Moment} startDate
  */
-export function setStartDate(date: moment.Moment) {
+export function setStartDate(startDate: moment.Moment) {
   return {
     type: SET_START_DATE,
-    date
+    startDate
   };
 }
 
 /**
  * Sets the set endDate value
  *
- * @param {moment.Moment} date
+ * @param {moment.Moment} endDate
  */
-export function setEndDate(date: moment.Moment) {
+export function setEndDate(endDate: moment.Moment) {
   return {
     type: SET_END_DATE,
-    date
+    endDate
   };
 }
 

--- a/src/state/actions/DataRangeAction.ts
+++ b/src/state/actions/DataRangeAction.ts
@@ -1,0 +1,31 @@
+import moment from 'moment';
+
+import {
+  SET_START_DATE,
+  SET_END_DATE
+} from '../constants/DataRange';
+
+/**
+ * Sets the set startDate value
+ *
+ * @param {moment.Moment} date
+ */
+export function setStartDate(date: moment.Moment) {
+  return {
+    type: SET_START_DATE,
+    date
+  };
+}
+
+/**
+ * Sets the set endDate value
+ *
+ * @param {moment.Moment} date
+ */
+export function setEndDate(date: moment.Moment) {
+  return {
+    type: SET_END_DATE,
+    date
+  };
+}
+

--- a/src/state/constants/DataRange.ts
+++ b/src/state/constants/DataRange.ts
@@ -1,0 +1,2 @@
+export const SET_START_DATE = 'SET_START_DATE';
+export const SET_END_DATE = 'SET_END_DATE';

--- a/src/state/initialState.ts
+++ b/src/state/initialState.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export default {
   mapView: {
     present: {
@@ -28,5 +30,9 @@ export default {
   },
   appState: {
     addLayerWindowVisible: false
+  },
+  dataRange: {
+    startDate: moment(moment.now()).subtract(1, 'days'),
+    endDate: moment(moment.now()).add(1, 'days')
   }
 };

--- a/src/state/reducers/DataRangeReducer.spec.ts
+++ b/src/state/reducers/DataRangeReducer.spec.ts
@@ -1,0 +1,67 @@
+/*eslint-env jest*/
+import reducer from './DataRangeReducer';
+import moment from 'moment';
+import {
+  SET_START_DATE,
+  SET_END_DATE
+} from '../constants/DataRange';
+
+
+describe('LoadingReducer', () => {
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual({});
+  });
+
+  it('should handle SET_START_DATE', () => {
+    const startDate = moment(moment.now());
+
+    // test with empty initial state
+    const state = {
+      startDate
+    };
+    const defaultAction = {
+      type: SET_START_DATE,
+      startDate
+    };
+
+    expect(reducer({}, defaultAction)).toEqual(state);
+
+    // test with existing state
+    const changedDate = startDate.add(1, 'hours');
+    const action = {
+      type: SET_START_DATE,
+      startDate: changedDate
+    };
+
+    expect(reducer(state, action)).toEqual({
+      startDate: changedDate
+    });
+  });
+
+  it('should handle SET_END_DATE', () => {
+    const endDate = moment(moment.now());
+
+    // test with empty initial state
+    const state = {
+      endDate
+    };
+    const defaultAction = {
+      type: SET_END_DATE,
+      endDate
+    };
+
+    expect(reducer({}, defaultAction)).toEqual(state);
+
+    // test with existing state
+    const changedDate = endDate.add(1, 'hours');
+    const action = {
+      type: SET_END_DATE,
+      endDate: changedDate
+    };
+
+    expect(reducer(state, action)).toEqual({
+      endDate: changedDate
+    });
+  });
+});

--- a/src/state/reducers/DataRangeReducer.ts
+++ b/src/state/reducers/DataRangeReducer.ts
@@ -1,0 +1,23 @@
+import {
+  SET_START_DATE,
+  SET_END_DATE
+} from '../constants/DataRange';
+
+const initialState: any = {};
+
+/**
+ */
+function setDataRange(dataRange = initialState, action: any) {
+  switch (action.type) {
+    case SET_START_DATE: {
+      return { ...dataRange, startDate: action.date };
+    }
+    case SET_END_DATE: {
+      return { ...dataRange, endDate: action.date };
+    }
+    default:
+      return dataRange;
+  }
+}
+
+export default setDataRange;

--- a/src/state/reducers/DataRangeReducer.ts
+++ b/src/state/reducers/DataRangeReducer.ts
@@ -10,10 +10,10 @@ const initialState: any = {};
 function setDataRange(dataRange = initialState, action: any) {
   switch (action.type) {
     case SET_START_DATE: {
-      return { ...dataRange, startDate: action.date };
+      return { ...dataRange, startDate: action.startDate };
     }
     case SET_END_DATE: {
-      return { ...dataRange, endDate: action.date };
+      return { ...dataRange, endDate: action.endDate };
     }
     default:
       return dataRange;

--- a/src/state/reducers/Reducer.ts
+++ b/src/state/reducers/Reducer.ts
@@ -9,6 +9,7 @@ import appInfo  from './ApplicationInfoReducer';
 import mapLayers from './MapLayersReducer';
 import activeModules  from './ActiveModulesReducer';
 import fetchRemoteFeaturesOfType  from './RemoteFeatureReducer';
+import dataRange from './DataRangeReducer';
 import appState  from './AppStateReducer';
 
 // We need outerReducer to replace full state as soon as it has loaded
@@ -22,6 +23,7 @@ const baseclientMainReducer = outerReducer(combineReducers({
   appState,
   appContext: (appContext = {}) => appContext,
   hoverFeatures: fetchRemoteFeaturesOfType('HOVER'),
+  dataRange,
   // We need innerReducer to store loading state, i.e. for showing loading spinner
   asyncInitialState: innerReducer
 }));

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -218,6 +218,7 @@ class AppContextUtil {
       layerNames,
       crossOrigin,
       requestWithTiled,
+      timeFormat,
       type
     } = layerObj.source;
 
@@ -230,6 +231,8 @@ class AppContextUtil {
       legendUrl
     } = layerObj.appearance;
 
+    const defaultFormat = timeFormat || 'YYYY-MM-DD';
+
     const layerSource = new OlTileWMS({
       url: url,
       attributions: attribution,
@@ -238,7 +241,7 @@ class AppContextUtil {
         'LAYERS': layerNames,
         'TILED': requestWithTiled || false,
         'TRANSPARENT': true,
-        'TIME': type === 'WMSTime' ? moment(moment.now()).format(layerObj.timeFormat) : undefined
+        'TIME': type === 'WMSTime' ? moment(moment.now()).format(defaultFormat) : undefined
       },
       crossOrigin: crossOrigin
     });
@@ -258,8 +261,11 @@ class AppContextUtil {
     tileLayer.set('topic', layerObj.topic);
     tileLayer.set('staticImageUrl', layerObj.staticImageUrl);
     tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
-    tileLayer.set('timeFormat', layerObj.source.timeFormat);
-
+    tileLayer.set('timeFormat', defaultFormat);
+    if (type === 'WMSTime') {
+      tileLayer.set('startDate', moment(layerObj.startDate).format(defaultFormat));
+      tileLayer.set('endDate', moment(layerObj.endDate).format(defaultFormat));
+    }
     return tileLayer;
   }
 

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -263,8 +263,10 @@ class AppContextUtil {
     tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
     tileLayer.set('timeFormat', defaultFormat);
     if (type === 'WMSTime') {
-      tileLayer.set('startDate', moment(layerObj.startDate).format(defaultFormat));
-      tileLayer.set('endDate', moment(layerObj.endDate).format(defaultFormat));
+      const startDate = layerObj.startDate ? moment(layerObj.startDate).format(defaultFormat) : undefined;
+      const endDate = layerObj.endDate ? moment(layerObj.endDate).format(defaultFormat) : undefined;
+      tileLayer.set('startDate', startDate);
+      tileLayer.set('endDate', endDate);
     }
     return tileLayer;
   }


### PR DESCRIPTION
* Store main settings for time slider (`startDate` and `endDate`) in global state
* Disable component (via CSS) if no time aware layers are currently in the map
* Use custom date format if set on the layer on slider
* Fix several bugs
  * Reenable sliding
  * Prevent unnecessary render calls
  * Fix autoplay function for numeric values like `x10`

Please review @terrestris/devs 

