### PR TITLE
Dispatch nodeVisibilityChanged event

### DIFF
--- a/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -19,6 +19,7 @@ interface DefaultLayerLegendAccordionNodeProps {
 
 interface LayerLegendAccordionNodeProps extends Partial<DefaultLayerLegendAccordionNodeProps>{
   t: (arg: string) => {};
+  map: any;
 }
 
 interface LayerLegendAccordionNodeState {
@@ -163,6 +164,8 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
   onLayerTreeNodeVisibilityChange(layer: any) {
     const nextLayerVisibility = !layer.getVisible();
     layer.setVisible(nextLayerVisibility);
+
+    this.props.map.dispatchEvent('nodeVisibilityChanged');
 
     // we need to do this since legend needs to be redrawn
     this.forceUpdate();

--- a/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
+++ b/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
@@ -170,11 +170,13 @@ export class LayerLegendAccordion extends React.Component<LayerLegendAccordionPr
    */
   treeNodeTitleRenderer(layer: any) {
     const {
-      t
+      t,
+      map
     } = this.props;
 
     return (
       <LayerLegendAccordionTreeNode
+        map={map}
         t={t}
         layer={layer}
       />
@@ -294,6 +296,7 @@ export class LayerLegendAccordion extends React.Component<LayerLegendAccordionPr
     }
     // update all layers
     filteredLayers.forEach(l => l.setVisible(visibility));
+    this.props.map.dispatchEvent('nodeVisibilityChanged');
 
     // we need to do this since legend needs to be redrawn
     this.forceUpdate();

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -162,6 +162,7 @@ class AppContextUtil {
         tileLayer.set('type', 'WMTS');
         tileLayer.set('legendUrl', legendUrl);
         tileLayer.set('isBaseLayer', layerObj.isBaseLayer);
+        tileLayer.set('isDefault', layerObj.isDefault);
         tileLayer.set('topic', layerObj.topic);
         tileLayer.set('staticImageUrl', layerObj.staticImageUrl);
         tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
@@ -258,6 +259,7 @@ class AppContextUtil {
     tileLayer.set('type', type);
     tileLayer.set('legendUrl', legendUrl);
     tileLayer.set('isBaseLayer', layerObj.isBaseLayer);
+    tileLayer.set('isDefault', layerObj.isDefault);
     tileLayer.set('topic', layerObj.topic);
     tileLayer.set('staticImageUrl', layerObj.staticImageUrl);
     tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
@@ -315,6 +317,7 @@ class AppContextUtil {
     imageLayer.set('type', type);
     imageLayer.set('legendUrl', legendUrl);
     imageLayer.set('isBaseLayer', layerObj.isBaseLayer);
+    imageLayer.set('isDefault', layerObj.isDefault);
     imageLayer.set('topic', layerObj.topic);
     imageLayer.set('staticImageUrl', layerObj.staticImageUrl);
 


### PR DESCRIPTION
Dispatch custom `nodeVisibilityChanged` event each time when layer tree node was (un)checked. This allows other components which have listeners registered on it to react on these changes in a proper way.

Event listener can be added in target components as usual like `map.on('nodeVisibilityChanged', someCallbackFn)`

Additionally set `isDefault` property on layers.

Please review @terrestris/devs  