### PR TITLE
Set static image urls for image layers and vector tile layers

### DIFF
--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -117,6 +117,8 @@ class AppContextUtil {
         if (!layerObj.appearance.visible) {
           vectorLayer.set('visible', false);
         }
+        vectorLayer.set('staticImageUrl', layerObj.staticImageUrl);
+        vectorLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
         layers.push(vectorLayer);
       }
 
@@ -320,6 +322,7 @@ class AppContextUtil {
     imageLayer.set('isDefault', layerObj.isDefault);
     imageLayer.set('topic', layerObj.topic);
     imageLayer.set('staticImageUrl', layerObj.staticImageUrl);
+    imageLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
 
     return imageLayer;
   }


### PR DESCRIPTION
In particular, the following (missing) configs can be set for image WMS layers and vector tile tiles now:
* `staticImageUrl`: Use this image URL in preview
* `previewImageRequestUrl`: Use this base URL to build WMS request for preview

Plz review @annarieger 