### PR TITLE
Add possibility to hide tools (modules) via `hidden` flag

### DIFF
--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -364,6 +364,9 @@ class AppContextUtil {
     const mapConfig = ObjectUtil.getValue('mapConfig', appContext);
 
     activeModules.forEach((module: any) => {
+      if (module.hidden) {
+        return;
+      }
       switch(module.xtype) {
         case 'basigx-button-zoomin':
           tools.push(<ZoomButton


### PR DESCRIPTION
This way the tools can be easily turned hidden in client, when configured like:
```
{
    "id": 45,
    "name": "My tool",
    "hidden": true
     [...]
}
```

Please review @weskamm 