### PR TITLE
Add `defaultTopic` config

### DIFF
--- a/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
+++ b/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
@@ -87,7 +87,7 @@ export class LayerLegendAccordion extends React.Component<LayerLegendAccordionPr
     this.state = {
       loadingQueue: [],
       mainAccordionActiveKeys: ['tree', 'legend'],
-      themeLayerActiveKeys: [],
+      themeLayerActiveKeys: ['theme'],
       baseLayerActiveKeys: [],
       externalLayerActiveKeys: [],
       legendImageActiveKeys: []

--- a/src/state/initialState.ts
+++ b/src/state/initialState.ts
@@ -17,6 +17,7 @@ export default {
     name: 'React-geo baseclient',
     versionNumber: '0.1 (dev)'
   },
+  defaultTopic: null,
   loadingQueue: {
     queue: [],
     loading: false

--- a/src/state/reducers/Reducer.ts
+++ b/src/state/reducers/Reducer.ts
@@ -19,6 +19,7 @@ const baseclientMainReducer = outerReducer(combineReducers({
   appInfo,
   mapLayers,
   activeModules,
+  defaultTopic: (state = {}) => state,
   mapScales: (state = {}) => state,
   appState,
   appContext: (appContext = {}) => appContext,

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -51,6 +51,7 @@ class AppContextUtil {
     const mapConfig = ObjectUtil.getValue('mapConfig', appContext);
     const mapLayers = ObjectUtil.getValue('mapLayers', appContext);
     const activeModules = ObjectUtil.getValue('activeTools', appContext);
+    const defaultTopic = ObjectUtil.getValue('defaultTopic', appContext);
 
     // AppInfo
     state.appInfo.name = appContext.name || state.appInfo.name;
@@ -78,6 +79,9 @@ class AppContextUtil {
     state.activeModules = union(state.activeModules, activeModules);
 
     state.appContext = appContext;
+
+    // default topic name
+    state.defaultTopic = defaultTopic;
 
     // map scales
     state.mapScales = AppContextUtil.getMapScales(mapConfig.resolutions);


### PR DESCRIPTION
Add and consider `defaultTopic` config containing name of the layer topic which should be shown on first initial application load.

If no `defaultTopic` is configured, only base  layer will be shown (old default app behaviour).

Please review @terrestris/devs 