### PR TITLE
Remove DE countrycode from nominatim

### DIFF
--- a/src/component/container/Header/Header.tsx
+++ b/src/component/container/Header/Header.tsx
@@ -143,6 +143,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
           >
             <NominatimSearch
               placeholder={t('Header.nominatimPlaceHolder')}
+              countrycodes={''}
               map={map}
               style={{
                 width: '100%'


### PR DESCRIPTION
Enables nomitaim search outside from Germany (default react-geo [Nominatim](https://github.com/terrestris/react-geo/blob/master/src/Field/NominatimSearch/NominatimSearch.tsx#L121) component behaviour)

Please review @terrestris/devs 