### PR TITLE
Various fixes

### DIFF
--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -335,6 +335,9 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   updateDataRange([startDate, endDate]: timeRange) {
     this.props.dispatch(setStartDate(startDate));
     this.props.dispatch(setEndDate(endDate));
+    this.setState({
+      value: startDate!.clone().add(endDate!.diff(startDate) / 2)
+    }, () => this.wrapTimeSlider());
   }
 
   /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import './i18n';
-import { LocaleProvider } from 'antd';
+import { ConfigProvider } from 'antd';
 import 'antd/dist/antd.min.css'; // should be working via the loader but it does not..
 import deDE from 'antd/lib/locale-provider/de_DE';
 import { defaults as OlDefaultControls } from 'ol/control/util';
@@ -100,13 +100,13 @@ const MappifiedMain = (mappify)(Main);
 
 render(
   <React.Suspense fallback={<div>Loading...</div>}>
-    <LocaleProvider locale={deDE}>
+    <ConfigProvider locale={deDE}>
       <Provider store={store}>
         <MapProvider map={mapPromise}>
           <MappifiedMain />
         </MapProvider>
       </Provider>
-    </LocaleProvider>
+    </ConfigProvider>
   </React.Suspense>,
   document.getElementById('app')
 );

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -171,6 +171,7 @@ class AppContextUtil {
         tileLayer.set('isDefault', layerObj.isDefault);
         tileLayer.set('topic', layerObj.topic);
         tileLayer.set('staticImageUrl', layerObj.staticImageUrl);
+        tileLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
         tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
         tileLayer.set('timeFormat', layerObj.source.timeFormat);
         layers.push(tileLayer);
@@ -276,6 +277,7 @@ class AppContextUtil {
       tileLayer.set('startDate', startDate);
       tileLayer.set('endDate', endDate);
     }
+    tileLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
     return tileLayer;
   }
 
@@ -327,6 +329,7 @@ class AppContextUtil {
     imageLayer.set('topic', layerObj.topic);
     imageLayer.set('staticImageUrl', layerObj.staticImageUrl);
     imageLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
+    imageLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
 
     return imageLayer;
   }


### PR DESCRIPTION
* Replaced deprecated antd LocaleProvider by ConfigProvider
* Ensures that current time slider value is inside of range after time range was changed (e.g. new layer with some other start and end data was chosen)
* Introduces custom `converFeatureInfoValue` property on layer to enable customization/manipulation of original feature properties before these will be shown in `FeatureInfoGrid`. Implementaion of converting methods should be done in child project classes.

Please review @terrestris/devs 

 