### PR TITLE
Layer properties menu with layer description item

### DIFF
--- a/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
-  Tooltip,
-  Dropdown
+  Tooltip
 } from 'antd';
 
 import OlLayerGroup from 'ol/layer/Group';
@@ -9,6 +8,7 @@ import OlTileWmsSource from 'ol/source/TileWMS';
 import OlImageWmsSource from 'ol/source/Image';
 
 import LayerTransparencySlider from '@terrestris/react-geo/dist/Slider/LayerTransparencySlider';
+import LayerTreeDropdownContextMenu from '../container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu';
 
 import './LayerLegendAccordionTreeNode.less';
 
@@ -258,23 +258,11 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
           className={loadingSpanClass}
         />
         {
-          !(layer instanceof OlLayerGroup) ?
-            <Dropdown
-              overlay={<div />} // TODO: make something more senseful here
-              placement="topLeft"
-              trigger={['click']}
-            >
-              <Tooltip
-                title={this.props.t('LayerLegendAccordion.layerSettingsTooltipText')}
-                placement="right"
-                mouseEnterDelay={0.5}
-              >
-                <span
-                  className="fa fa-cog layer-tree-node-title-settings"
-                />
-              </Tooltip>
-            </Dropdown> :
-            null
+          !(layer instanceof OlLayerGroup) &&
+            <LayerTreeDropdownContextMenu
+              map={this.props.map}
+              layer={layer}
+              t={t} />
         }
         </div>
         <LayerTransparencySlider

--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.spec.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.spec.tsx
@@ -1,0 +1,36 @@
+/*eslint-env jest*/
+import TestUtils from '../../../../config/jest/spec/TestUtils';
+
+import LayerTreeDropdownContextMenu from './LayerTreeDropdownContextMenu';
+
+describe('<LayerTreeDropdownContextMenu />', () => {
+  let layer;
+  let map;
+  let wrapper: any;
+
+  beforeEach(() => {
+    layer = TestUtils.createTileLayer({});
+    map = TestUtils.createMap({});
+    wrapper = TestUtils.mountComponent(LayerTreeDropdownContextMenu, {
+      t: () => {},
+      layer,
+      map,
+    }, {});
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    TestUtils.unmountMapDiv();
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(LayerTreeDropdownContextMenu).not.toBe(undefined);
+    });
+
+    it('can be rendered', () => {
+      expect(wrapper).not.toBe(undefined);
+    });
+  });
+
+});

--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+
+import OlLayerBase from 'ol/layer/Base';
+
+import {
+  Menu,
+  Dropdown,
+  Tooltip,
+  Modal
+} from 'antd';
+const MenuItem = Menu.Item;
+
+const _isEmpty = require('lodash/isEmpty');
+
+interface LayerTreeDropdownContextMenuProps {
+  layer: OlLayerBase;
+  t: (arg: string) => {};
+  map: any;
+}
+
+interface LayerTreeDropdownContextMenuState {
+  infoModalVisible: boolean;
+  menuHidden: boolean;
+}
+
+/**
+ * Class LayerTreeDropdownContextMenu.
+ *
+ * @class LayerTreeDropdownContextMenu
+ * @extends React.Component
+ */
+export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropdownContextMenuProps, LayerTreeDropdownContextMenuState> {
+
+  /**
+   * Creates the LayerTreeDropdownContextMenu.
+   *
+   * @constructs LayerTreeDropdownContextMenu
+   */
+  constructor(props: LayerTreeDropdownContextMenuProps) {
+    super(props);
+
+    // binds
+    this.onContextMenuItemClick = this.onContextMenuItemClick.bind(this);
+    this.changeInfoModalVisibility = this.changeInfoModalVisibility.bind(this);
+    this.onDropdownMenuVisibleChange = this.onDropdownMenuVisibleChange.bind(this);
+
+    this.state = {
+      infoModalVisible: false,
+      menuHidden: true
+    };
+  }
+
+  /**
+   * Called if the an item of the layer context/settings menu has been clicked.
+   *
+   * @param {Object} evt The click event.
+   */
+  onContextMenuItemClick(evt: any) {
+    const key = evt.key;
+    switch(key) {
+      case 'info':
+        this.changeInfoModalVisibility();
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Handles visibility of the dropdown menu
+   *
+   */
+  onDropdownMenuVisibleChange(visible: boolean) {
+    this.setState({
+      menuHidden: !visible
+    });
+  }
+
+  /**
+   * Opens the info modal window for the current layer.
+   */
+  changeInfoModalVisibility() {
+    this.setState({
+      infoModalVisible: !this.state.infoModalVisible,
+      menuHidden: true
+    });
+  }
+
+
+  /**
+   * The render function.
+   */
+  render () {
+    const {
+      t,
+      layer
+    } = this.props;
+
+    const {
+      infoModalVisible,
+      menuHidden
+    } = this.state;
+
+    const settingsMenu = (
+      <Menu
+        selectable={false}
+        onClick={this.onContextMenuItemClick}
+      >
+        <MenuItem
+          disabled={_isEmpty(layer.get('description'))}
+          key="info"
+        >
+          {t('LayerTreeDropdownContextMenu.layerInfoText')}
+        </MenuItem>
+      </Menu>
+    );
+
+    return (
+      <div>
+        <Modal
+          className="info-modal"
+          visible={infoModalVisible}
+          footer={null}
+          title={layer.get('name') || t('Modal.LayerDescription.title')}
+          onCancel={() => this.changeInfoModalVisibility()}
+        >
+          <div>{layer.get('description')}</div>
+        </Modal>
+        <Dropdown
+          overlay={settingsMenu}
+          placement="bottomLeft"
+          onVisibleChange={this.onDropdownMenuVisibleChange}
+          visible={!menuHidden}
+          trigger={['click']}
+        >
+          <Tooltip
+            title={this.props.t('LayerTreeDropdownContextMenu.layerSettingsTooltipText')}
+            placement="right"
+            mouseEnterDelay={0.5}
+          >
+            <span
+              className="fa fa-cog layer-tree-node-title-settings"
+            />
+          </Tooltip>
+        </Dropdown>
+      </div>
+    );
+  }
+}
+
+export default LayerTreeDropdownContextMenu;

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -75,7 +75,6 @@
   },
   "LayerLegendAccordion": {
     "toggleVisibilityTooltipText": "Sichtbarkeit",
-    "layerSettingsTooltipText": "Eigenschaften",
     "layerTreeTitle": "Layerliste",
     "showLayerTreeTooltipText": "Layerliste / Legende anzeigen",
     "legendPanelTitle": "Legende",
@@ -104,6 +103,13 @@
   "Modal": {
     "Help": {
       "title": "Hilfe"
+    },
+    "LayerDescription": {
+      "title": "Layerbeschreibung"
     }
+  },
+  "LayerTreeDropdownContextMenu": {
+    "layerInfoText": "Layerbeschreibung",
+    "layerSettingsTooltipText": "Eigenschaften"
   }
 }

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -75,7 +75,6 @@
   },
   "LayerLegendAccordion": {
     "toggleVisibilityTooltipText": "Visibility",
-    "layerSettingsTooltipText": "Properties",
     "layerTreeTitle": "Layer list",
     "showLayerTreeTooltipText": "Show layer list / legend",
     "legendPanelTitle": "Legend",
@@ -104,6 +103,13 @@
   "Modal": {
     "Help": {
       "title": "Help"
+    },
+    "LayerDescription": {
+      "title": "Layer description"
     }
+  },
+  "LayerTreeDropdownContextMenu": {
+    "layerInfoText": "Layer description",
+    "layerSettingsTooltipText": "Properties"
   }
 }

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -174,6 +174,7 @@ class AppContextUtil {
         tileLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
         tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
         tileLayer.set('timeFormat', layerObj.source.timeFormat);
+        tileLayer.set('description', layerObj.description);
         layers.push(tileLayer);
         return;
       }
@@ -271,6 +272,7 @@ class AppContextUtil {
     tileLayer.set('staticImageUrl', layerObj.staticImageUrl);
     tileLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
     tileLayer.set('timeFormat', defaultFormat);
+    tileLayer.set('description', layerObj.description);
     if (type === 'WMSTime') {
       const startDate = layerObj.startDate ? moment(layerObj.startDate).format(defaultFormat) : undefined;
       const endDate = layerObj.endDate ? moment(layerObj.endDate).format(defaultFormat) : undefined;
@@ -330,6 +332,7 @@ class AppContextUtil {
     imageLayer.set('staticImageUrl', layerObj.staticImageUrl);
     imageLayer.set('previewImageRequestUrl', layerObj.previewImageRequestUrl);
     imageLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
+    imageLayer.set('description', layerObj.description);
 
     return imageLayer;
   }


### PR DESCRIPTION
Add "Layer description" menu item to layer properties menu shown on click on settings button right to the layer name in layer tree.

![image](https://user-images.githubusercontent.com/3939355/72420446-04418b00-377f-11ea-887a-34a0c9d0698f.png)

If description set on layer, a modal showing its content will be shown on menu item click.

Please review @terrestris/devs 