### PR TITLE
Fix HSI requests for FeatureInfoPopup

### DIFF
--- a/src/component/Map/Map.tsx
+++ b/src/component/Map/Map.tsx
@@ -177,8 +177,7 @@ export class Map extends React.Component<MapProps, MapState> {
    * @param {ol.event} olEvt The ol event.
    */
   checkPointerRest(olEvt: any) {
-    if (olEvt.dragging || !this.state.isMouseOverMapEl ||
-        !(olEvt.target.getRenderer().canvas_)) {
+    if (olEvt.dragging || !this.state.isMouseOverMapEl) {
       return;
     }
 

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -139,8 +139,11 @@ export class HsiButton extends React.Component<HsiButtonProps> {
     let infoUrlsToCombine: any = {};
     map.forEachLayerAtPixel(pixel, (layer: any) => {
       const layerSource: any = layer.getSource();
-      const featureInfoUrl: string = layerSource.getGetFeatureInfoUrl(
-          olEvt.coordinate,
+      if(!layerSource.getFeatureInfoUrl) {
+        return;
+      }
+      const featureInfoUrl: string = layerSource.getFeatureInfoUrl(
+          map.getCoordinateFromPixel(pixel),
           viewResolution,
           viewProjection,
         {
@@ -171,7 +174,7 @@ export class HsiButton extends React.Component<HsiButtonProps> {
     if (Object.keys(infoUrlsToCombine).length > 0) {
       Object.keys(infoUrlsToCombine).forEach(key => {
         const url: any = UrlUtil.bundleOgcRequests(infoUrlsToCombine[key], true);
-        featureInfoUrls.push(url);
+        featureInfoUrls = featureInfoUrls.concat(url);
       });
     }
 

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -139,7 +139,7 @@ export class HsiButton extends React.Component<HsiButtonProps> {
     let infoUrlsToCombine: any = {};
     map.forEachLayerAtPixel(pixel, (layer: any) => {
       const layerSource: any = layer.getSource();
-      if(!layerSource.getFeatureInfoUrl) {
+      if (!layerSource.getFeatureInfoUrl) {
         return;
       }
       const featureInfoUrl: string = layerSource.getFeatureInfoUrl(

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -431,7 +431,7 @@ class AppContextUtil {
             t={t}
           />);
           return;
-        case 'shogun-button-hsi':
+        case 'basigx-button-hsi':
           tools.push(<HsiButton
             map={map}
             key="5"


### PR DESCRIPTION
This MR

*  fixes `Map`, `HsiButton` and `AppContextUtil` to allow queries on a layer and the display of corresponding features in the `FeatureInfoPopup` based on the previous update of react-geo.

Thanks for your support @hwbllmnn @dnlkoch !

@terrestris/devs please review