### PR TITLE
Footer ProjectionSwitcher Add Disable Option

### DIFF
--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -33,6 +33,7 @@ interface FooterProps extends Partial<DefaultFooterProps>{
   t: (arg: string) => {};
   mapScales: number[];
   projection: string;
+  disableCrsSelection: boolean;
 }
 
 interface FooterState {
@@ -196,6 +197,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
       map,
       mapScales,
       projection,
+      disableCrsSelection,
       imprintLink,
       imprintText,
       t
@@ -215,6 +217,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
               onSelect={this.setProjection}
               emptyTextPlaceholderText={t('CoordinateReferenceSystemCombo.emptyTextPlaceholderText') as string}
               value={projection.replace('EPSG:', '')}
+              disabled={disableCrsSelection || false}
             />
           </Col>
           <Col


### PR DESCRIPTION
Add option to disable selection of projection. Default CRS (EPSG:3857) is used.  `Footer.tsx`
![image](https://user-images.githubusercontent.com/37144910/97886312-bce5b480-1d28-11eb-9889-be4e06a50eb2.png) 

 @terrestris/devs What do you think?
