### PR TITLE
Reintegrate hover feature info

### DIFF
--- a/src/component/Map/Map.tsx
+++ b/src/component/Map/Map.tsx
@@ -47,6 +47,7 @@ interface MapProps extends Partial<DefaultMapProps> {
 interface MapState {
   lastPointerPixel: number[] | null;
   isMouseOverMapEl: boolean;
+  mouseEvt: MouseEvent;
 }
 
 /**
@@ -108,6 +109,11 @@ export class Map extends React.Component<MapProps, MapState> {
 
     this.initDebouncedCheckPointerRest(this.props.pointerRestInterval);
     this.setFirePointerRest(this.props.firePointerRest);
+    document.addEventListener('mousemove', (evt) => {
+      this.setState({
+        mouseEvt: evt
+      });
+    });
   }
 
   /**
@@ -181,6 +187,19 @@ export class Map extends React.Component<MapProps, MapState> {
    */
   checkPointerRest(olEvt: any) {
     if (olEvt.dragging || !this.state.isMouseOverMapEl) {
+      return;
+    }
+
+    const mouseX = this.state.mouseEvt.clientX;
+    const mouseY = this.state.mouseEvt.clientY;
+    const olX = olEvt.originalEvent.clientX;
+    const olY = olEvt.originalEvent.clientY;
+
+    // cancel if we have a diff between openlayers event coordinates and
+    // browser coordinates. This may happen when moving the mouse on a feature
+    // info window, where openlayers will trigger a mouseout event at the
+    // border of the window and falsely indicate a hover event
+    if (mouseX !== olX || mouseY !== olY) {
       return;
     }
 

--- a/src/component/Map/Map.tsx
+++ b/src/component/Map/Map.tsx
@@ -134,6 +134,20 @@ export class Map extends React.Component<MapProps, MapState> {
   }
 
   /**
+   * Called on lifecycle componentWillUnmount.
+   */
+  componentWillUnmount() {
+    const map = this.props.map;
+    map.un('moveend', this.onMapMoveEnd);
+    map.un('change:view', this.onMapViewChange);
+    document.removeEventListener('mousemove', (evt) => {
+      this.setState({
+        mouseEvt: evt
+      });
+    });
+  }
+
+  /**
    * (Un-)Registers the debouncedCheckPointerRest method on `pointermove`.
    *
    * @param {Boolean} state Whether to enable or disable the listener.

--- a/src/component/Map/Map.tsx
+++ b/src/component/Map/Map.tsx
@@ -88,6 +88,7 @@ export class Map extends React.Component<MapProps, MapState> {
     this.onMouseOver = this.onMouseOver.bind(this);
     this.onMouseOut = this.onMouseOut.bind(this);
     this.checkPointerRest = this.checkPointerRest.bind(this);
+    this.trackMousePosition = this.trackMousePosition.bind(this);
   }
 
   /**
@@ -109,11 +110,7 @@ export class Map extends React.Component<MapProps, MapState> {
 
     this.initDebouncedCheckPointerRest(this.props.pointerRestInterval);
     this.setFirePointerRest(this.props.firePointerRest);
-    document.addEventListener('mousemove', (evt) => {
-      this.setState({
-        mouseEvt: evt
-      });
-    });
+    document.addEventListener('mousemove', this.trackMousePosition);
   }
 
   /**
@@ -140,10 +137,15 @@ export class Map extends React.Component<MapProps, MapState> {
     const map = this.props.map;
     map.un('moveend', this.onMapMoveEnd);
     map.un('change:view', this.onMapViewChange);
-    document.removeEventListener('mousemove', (evt) => {
-      this.setState({
-        mouseEvt: evt
-      });
+    document.removeEventListener('mousemove', this.trackMousePosition);
+  }
+
+  /**
+   * Track mouse position for comparison purposes
+   */
+  trackMousePosition(evt: MouseEvent) {
+    this.setState({
+      mouseEvt: evt
     });
   }
 

--- a/src/component/Popup/FeatureInfo/FeatureInfo.tsx
+++ b/src/component/Popup/FeatureInfo/FeatureInfo.tsx
@@ -8,12 +8,56 @@ const isEqual = require('lodash/isEqual');
 import './FeatureInfo.less';
 
 interface DefaultFeatureInfoProps {
-  offset: [number, number];
+  /**
+   * The width of the popup.
+   * @type {Number}
+   */
+  width: number;
+
+  /**
+   * Offsets in pixels used when positioning the overlay. The first element
+   * in the array is the horizontal offset. A positive value shifts the
+   * overlay right. The second element in the array is the vertical offset.
+   * A positive value shifts the overlay down.
+   * @type {Array}
+   */
+  offset: number[];
+
+  /**
+   * Whether event propagation to the map viewport should be stopped. If true
+   * the overlay is placed in the same container as that of the controls
+   * (CSS class name ol-overlaycontainer-stopevent); if false it is placed in
+   * the container with CSS class name ol-overlaycontainer.
+   * @type {Boolean}
+   */
   stopEvent: boolean;
+
+  /**
+   * Whether the overlay is inserted first in the overlay container, or
+   * appended. If the overlay is placed in the same container as that of the
+   * controls (see the stopEvent option) you will probably set insertFirst to
+   * true so the overlay is displayed below the controls.
+   * @type {Boolean}
+   */
   insertFirst: boolean;
+
+  /**
+   * If set to true the map is panned when calling setPosition, so that the
+   * overlay is entirely visible in the current viewport.
+   * @type {Boolean}
+   */
   autoPan: boolean;
+
+  /**
+   * The animation options used to pan the overlay into view. This animation
+   * is only used when autoPan is enabled. A duration and easing may be
+   * provided to customize the animation.
+   * @type {Object}
+   */
   autoPanAnimationDuration: number;
+
   autoPanMargin: number;
+
   positioning: OverlayPositioning;
 }
 
@@ -21,10 +65,34 @@ interface FeatureInfoProps extends Partial<DefaultFeatureInfoProps> {
 
   map: OlMap;
   position: number[];
+  /**
+   * Defines how the overlay is actually positioned with respect to its
+   * position property. Possible values are 'bottom-left', 'bottom-center',
+   * 'bottom-right', 'center-left', 'center-center', 'center-right',
+   * 'top-left', 'top-center', and 'top-right'.
+   * @type {String}
+   */
+  positioning: OverlayPositioning;
+
+  /**
+   * Whether the component is loading (and should render a progress cursor)
+   * or not.
+   * @type {Boolean}
+   */
   isLoading: boolean;
+
+  /**
+   * The children elements to render inside the popup.
+   * @type {Element}
+   */
+  children: any;
 }
 
 interface FeatureInfoState {
+  /**
+   * The overlay position in map projection.
+   * @type {Array}
+   */
   position: number[];
 }
 
@@ -40,6 +108,7 @@ export class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoSt
  * The default properties.
  */
   public static defaultProps: DefaultFeatureInfoProps = {
+    width: 200,
     offset: [0, 0],
     stopEvent: false,
     insertFirst: true,
@@ -311,6 +380,9 @@ export class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoSt
       <div
         className='feature-info-popup'
         ref={this.featureInfoPopup}
+        style={{
+          width: this.props.width
+        }}
       >
         {children}
       </div>


### PR DESCRIPTION
This makes featureinfo by hover working again.
You can now configure if you want to get featureInfo by hover (default) or by click.

Reimplements parts from 
https://github.com/terrestris/react-geo-baseclient/commit/95d5dd3519eb7186132caa92d74dfcd50f3c6046

Fixes https://github.com/terrestris/react-geo-baseclient/issues/643