### PR TITLE
Change time dimension source field

### DIFF
--- a/src/component/container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval.tsx
+++ b/src/component/container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval.tsx
@@ -64,17 +64,17 @@ LayerTreeApplyTimeIntervalState
    */
   setTimeIntervalToTimeLine(layer: any) {
     const { dispatch } = this.props;
-    const layerDescription = layer.get('description') || undefined;
+    const layerTimeDimension = layer.get('timeDimension') || undefined;
     let timeDimension: any = [];
-    if (layerDescription) {
-      timeDimension = layerDescription.match(
+    if (layerTimeDimension) {
+      timeDimension = layerTimeDimension.match(
         new RegExp(/([^\s]*)[/]([^\s]*)[/]([^\s]*)/)
       );
 
       // check if timeDimension may be a list
       if (!timeDimension) {
         timeDimension = [];
-        const dimensionListText = layerDescription.match(
+        const dimensionListText = layerTimeDimension.match(
           new RegExp(/([^\s]*[,])([^\s]*)/)
         );
 


### PR DESCRIPTION
`layer.get("description")` should be reserved for metadata or other information that time dimension info.  

@terrestris/devs please check.