### PR TITLE
Disable console logging in production builds

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,6 +4,8 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import XHR from 'i18next-xhr-backend';
 import config from './config/config';
 
+const env = process.env.NODE_ENV;
+
 i18n
   .use(XHR)
   .use(LanguageDetector)
@@ -13,7 +15,7 @@ i18n
       loadPath: config.locale
     },
     fallbackLng: 'de',
-    debug: true,
+    debug: env === 'development' ? true : false,
 
     interpolation: {
       escapeValue: false // not needed for react!!

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -12,9 +12,11 @@ import appContextUtil from '../util/AppContextUtil';
 import config from '../config/config';
 import Logger from '@terrestris/base-util/dist/Logger';
 
-const loggerMiddleware = createLogger({
+const env = process.env.NODE_ENV;
+
+const loggerMiddleware = env === 'development' ? createLogger({
   collapsed: true
-});
+}) : middleware();
 
 /**
  * Load loadAppContextStore function


### PR DESCRIPTION
disables redux and i18n console logs in production mode.

fixes https://github.com/terrestris/react-geo-baseclient/issues/164

