### PR TITLE
Make header logo target optional, empty default

### DIFF
--- a/src/component/container/Header/Header.less
+++ b/src/component/container/Header/Header.less
@@ -15,6 +15,8 @@
   .logo {
     .app-logo {
       height: ~"calc(@{header-height} - 10px)";
+    }
+    .app-logo.with-link {
       &:hover {
         cursor: pointer;
       }

--- a/src/component/container/Header/Header.tsx
+++ b/src/component/container/Header/Header.tsx
@@ -14,7 +14,7 @@ import './Header.less';
 
 type LogoConfig = {
   src: string;
-  target: string;
+  target?: string;
 };
 
 // default props
@@ -48,10 +48,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     title: 'react-geo-baseclient',
     className: 'app-header',
     loading: false,
-    logoConfig: [{
-      src: 'logo_terrestris.png',
-      target: 'https://www.terrestris.de'
-    }]
+    logoConfig: undefined
   };
 
   /**
@@ -123,16 +120,16 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
           >
             <div className="logo">
               {
-                logoConfig.map((config, idx) =>
+                logoConfig ? logoConfig.map((config, idx) =>
                   <img
                     src={config.src}
                     key={`logo-${idx}`}
                     alt={config.target}
-                    className="app-logo"
-                    onClick={() => window.open(config.target, '_blank')}
+                    className={config.target ? 'app-logo with-link' : 'app-logo'}
+                    onClick={config.target ? () => window.open(config.target, '_blank') : () => {}}
                   />
                 )
-              }
+                  : null}
             </div>
           </Col>
           <Col


### PR DESCRIPTION
`target` is now an optional property.
The default behaviour, if not configured, is no logo at all