### PR TITLE
Introduce less file globbing

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -4,6 +4,7 @@ const paths = require('./paths.js');
 const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const lessPluginGlob = require('less-plugin-glob');
 
 const TARGET = process.env.npm_lifecycle_event;
 const PROJECT_MAIN_PATH = process.env.PROJECT_MAIN_PATH || './';
@@ -84,7 +85,9 @@ const commonWebpackConfig = {
           options: {
             lessOptions: {
               modifyVars: CustomCssTheme,
-              javascriptEnabled: true
+              javascriptEnabled: true,
+              plugins: [lessPluginGlob],
+              paths: [PROJECT_MAIN_PATH]
             }
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15305,6 +15305,104 @@
         }
       }
     },
+    "less-plugin-glob": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/less-plugin-glob/-/less-plugin-glob-3.0.0.tgz",
+      "integrity": "sha512-Zr8IP5UYK070glZbaNRjNObo0I4ILyTavJVMic0l7Uwmtv11eEfMOBN2cGfRYLjuH/KEjpVCZatYIqHvCFQ/hA==",
+      "dev": true,
+      "requires": {
+        "globby": "^8.0.1"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "dev": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+          "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "globby": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "jest-snapshot": "^26.4.2",
     "less": "^3.12.2",
     "less-loader": "^7.0.1",
+    "less-plugin-glob": "^3.0.0",
     "loglevel": "^1.7.0",
     "node-fetch": "^2.6.1",
     "object-assign": "^4.1.1",

--- a/src/ProjectMain.less
+++ b/src/ProjectMain.less
@@ -1,5 +1,6 @@
 @header-height: 50px;
 @footer-height: 35px;
+@toolbarColor: white;
 
 .viewport {
   display: flex;
@@ -10,7 +11,7 @@
 
 header {
   height: @header-height;
-  background-color: white;
+  background-color: @toolbarColor;
 }
 
 .main-content {
@@ -44,3 +45,4 @@ header {
   bottom: 78px;
 }
 
+@import './src/**/*.less';

--- a/src/component/AddLayerPanel/AddLayerPanel.tsx
+++ b/src/component/AddLayerPanel/AddLayerPanel.tsx
@@ -15,8 +15,6 @@ import Titlebar from '@terrestris/react-geo/dist/Panel/Titlebar/Titlebar';
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import CapabilitiesUtil from '@terrestris/ol-util/dist/CapabilitiesUtil/CapabilitiesUtil';
 
-import './AddLayerPanel.less';
-
 // default props
 interface DefaultAddLayerPanelProps {
   onCancel: () => any;

--- a/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
+++ b/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
@@ -9,8 +9,6 @@ import AgFeatureGrid from '@terrestris/react-geo/dist/Grid/AgFeatureGrid/AgFeatu
 import { CsvExportModule } from '@ag-grid-community/csv-export';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 
-import './FeatureInfoGrid.less';
-
 const uniqueId = require('lodash/uniqueId');
 const isEqual = require('lodash/isEqual');
 

--- a/src/component/LayerCarousel/LayerCarousel.tsx
+++ b/src/component/LayerCarousel/LayerCarousel.tsx
@@ -6,7 +6,6 @@ import '@brainhubeu/react-carousel/lib/style.css';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 
 import LayerCarouselSlide from '../LayerCarouselSlide/LayerCarouselSlide';
-import './LayerCarousel.less';
 
 interface DefaultLayerCarouselProps {
   map: any;

--- a/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
+++ b/src/component/LayerCarouselSlide/LayerCarouselSlide.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 
 import { Spin } from 'antd';
 
-import './LayerCarouselSlide.less';
-
 // default props
 export interface DefaultLayerCarouselSlideProps {
   width: number;

--- a/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -11,8 +11,6 @@ import LayerTransparencySlider from '@terrestris/react-geo/dist/Slider/LayerTran
 import LayerTreeDropdownContextMenu from '../container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu';
 import LayerTreeApplyTimeInterval from '../container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval';
 
-import './LayerLegendAccordionTreeNode.less';
-
 // default props
 interface DefaultLayerLegendAccordionNodeProps {
   layer: any;

--- a/src/component/Menu/FeatureInfo/FeatureInfo.tsx
+++ b/src/component/Menu/FeatureInfo/FeatureInfo.tsx
@@ -22,7 +22,6 @@ const isEmpty = require('lodash/isEmpty');
 import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import FeatureInfoGrid from '../../FeatureInfoGrid/FeatureInfoGrid';
 import { clearFeatures } from '../../../state/actions/RemoteFeatureAction';
-import './FeatureInfo.less';
 
 interface DefaultFeatureInfoProps {
   /**

--- a/src/component/Modal/Help/Help.tsx
+++ b/src/component/Modal/Help/Help.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Modal } from 'antd';
 
-import './Help.less';
-
 interface HelpProps {
   helpPdf: string;
   onCancel: (arg: any) => void;

--- a/src/component/Modal/Metadata/Metadata.tsx
+++ b/src/component/Modal/Metadata/Metadata.tsx
@@ -4,8 +4,6 @@ import { Modal, Descriptions } from 'antd';
 import MetadataParser from '../../../util/MetadataParser';
 import config from '../../../config/config';
 
-import './Metadata.less';
-
 const isEmpty = require('lodash/isEmpty');
 
 interface MetadataProps {

--- a/src/component/Popup/FeatureInfo/FeatureInfo.tsx
+++ b/src/component/Popup/FeatureInfo/FeatureInfo.tsx
@@ -5,8 +5,6 @@ import OverlayPositioning from 'ol/OverlayPositioning';
 
 const isEqual = require('lodash/isEqual');
 
-import './FeatureInfo.less';
-
 interface DefaultFeatureInfoProps {
   /**
    * The width of the popup.

--- a/src/component/PrintPanel/PrintPanelV2.tsx
+++ b/src/component/PrintPanel/PrintPanelV2.tsx
@@ -27,8 +27,6 @@ import { MapFishPrintV2Manager } from '@terrestris/mapfish-print-manager';
 
 import PrintUtil from '../../util/PrintUtil/PrintUtil';
 
-import './PrintPanelV2.less';
-
 interface DefaultPrintPanelV2Props {
   legendBlackList: string[];
   printLayerBlackList: string[];

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -28,8 +28,6 @@ import { MapFishPrintV3Manager } from '@terrestris/mapfish-print-manager';
 
 import PrintUtil from '../../util/PrintUtil/PrintUtil';
 
-import './PrintPanelV3.less';
-
 interface DefaultPrintPanelV3Props {
   legendBlackList: string[];
   printLayerBlackList: string[];

--- a/src/component/SiderMenu/SiderMenu.tsx
+++ b/src/component/SiderMenu/SiderMenu.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Layout, Menu } from 'antd';
 import { FileOutlined, DesktopOutlined, TeamOutlined, UserOutlined } from '@ant-design/icons';
-import './SiderMenu.less';
 
 import MeasureButton from '@terrestris/react-geo/dist/Button/MeasureButton/MeasureButton';
 import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';

--- a/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/component/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -26,8 +26,6 @@ import {
   setEndDate
 } from '../../state/actions/DataRangeAction';
 
-import './TimeLayerSliderPanel.less';
-
 type timeRange = [moment.Moment, moment.Moment];
 
 export interface DefaultTimeLayerSliderPanelProps {

--- a/src/component/button/MeasureMenuButton/MeasureMenuButton.tsx
+++ b/src/component/button/MeasureMenuButton/MeasureMenuButton.tsx
@@ -9,8 +9,6 @@ import OlInteractionDraw from 'ol/interaction/Draw';
 
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
-import './MeasureMenuButton.less';
-
 interface DefaultMeasureMenuButtonProps extends MeasureButtonProps {
   menuPlacement: 'left' | 'right';
 }

--- a/src/component/container/Footer/Footer.less
+++ b/src/component/container/Footer/Footer.less
@@ -1,5 +1,3 @@
-@import '../../../ProjectMain.less';
-
 .footer {
   height: @footer-height;
 

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import './Footer.less';
-
 import {
   Row,
   Col

--- a/src/component/container/Header/Header.less
+++ b/src/component/container/Header/Header.less
@@ -1,4 +1,3 @@
-@import '../../../ProjectMain.less';
 .app-header {
   border-bottom: 1px solid lightgray;
 
@@ -25,8 +24,6 @@
       display: none;
     }
   }
-
-
 
   .app-title {
     text-align: center;

--- a/src/component/container/Header/Header.tsx
+++ b/src/component/container/Header/Header.tsx
@@ -10,8 +10,6 @@ import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleB
 
 import { toggleHelpModal } from '../../../state/actions/AppStateAction';
 
-import './Header.less';
-
 type LogoConfig = {
   src: string;
   target?: string;

--- a/src/component/container/LayerLegendAccordion/LayerLegendAccordion.less
+++ b/src/component/container/LayerLegendAccordion/LayerLegendAccordion.less
@@ -1,4 +1,3 @@
-@import '../../../ProjectMain.less';
 @collapse-bckgr-color: #fafafa;
 @accordion-width: 400px;
 

--- a/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
+++ b/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
@@ -20,8 +20,6 @@ import {
   MapUtil
 } from '@terrestris/ol-util';
 
-import './LayerLegendAccordion.less';
-
 import LayerLegendAccordionTreeNode from '../../LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode';
 import { toggleAddLayerWindow } from '../../../state/actions/AppStateAction';
 

--- a/src/component/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
+++ b/src/component/container/LayerSetBaseMapChooser/LayerSetBaseMapChooser.tsx
@@ -12,8 +12,6 @@ import ToggleButton from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleB
 const isFunction = require('lodash/isFunction');
 const isEqual = require('lodash/isEqual');
 
-
-import './LayerSetBaseMapChooser.less';
 import LayerCarousel from '../../LayerCarousel/LayerCarousel';
 
 // default props


### PR DESCRIPTION
This introduces file globbing for less files.
This makes it possible to dynamically change less variables and apply the changes on all styles by reloading them all at once.

Example less file (which can be imported asynchronously!) to do so:
```
// import base client defaults
@import "./src/ProjectMain.less";

// apply customization
@toolbarColor: red;

// apply on all classes
@import "./src/**/*.less";
```
Besides there is no need anymore to include
  * the less import in the corresponding class
  * an import in the less file to the main file which holds less variables

This will of course get enhanced for better stylability by making use of harmoized variables in upcoming PRs

@terrestris/devs please review