### PR TITLE
Raise max tile loading

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,6 +58,7 @@ const setupMap = (state: any) => {
   const map = new OlMap({
     view: mapView,
     keyboardEventTarget: document,
+    maxTilesLoading: 128,
     controls: OlDefaultControls({
       zoom: false,
       attributionOptions: {


### PR DESCRIPTION
This raises the number of tiles the map may request simultaneously.
The default of 16 can be limiting when talking with http2 enabled origins.

@terrestris/devs please review