### PR TITLE
Filter *_LOADING actions from redux logger

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -15,7 +15,8 @@ import Logger from '@terrestris/base-util/dist/Logger';
 const env = process.env.NODE_ENV;
 
 const loggerMiddleware = env === 'development' ? createLogger({
-  collapsed: true
+  collapsed: true,
+  predicate: (getState, action) => !action.type.endsWith('_LOADING')
 }) : middleware();
 
 /**


### PR DESCRIPTION
This one removes a huge amount of same logger messages related to `ENABLE_LOADING` and `DISABLE_LOADING` actions from console.

![image](https://user-images.githubusercontent.com/3939355/103626711-e398b500-4f3c-11eb-91c9-95fbf2f26091.png)


@terrestris/devs 