### PR TITLE
Several print fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2927,9 +2927,9 @@
       }
     },
     "@terrestris/mapfish-print-manager": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-6.2.0.tgz",
-      "integrity": "sha512-WH1R3xqUZxLjEh5rFii6ObKTOvT0zcVjJlvi4vpezyDmfhXMxzlg9e7ghFQ4J9kD0288M4MP1B2b3S/wzS6jOQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-6.3.1.tgz",
+      "integrity": "sha512-hzFCMtBD7ire4LfIasq2dI4VgcQlsjgsOCyz/adq0Ocx9ZZljYT1/dEsog0D9Q9Zu87qObyFdAcMD0hNGLHrbw==",
       "requires": {
         "js-logger": "^1.6.0",
         "lodash": "^4.17.20",
@@ -2940,9 +2940,9 @@
       },
       "dependencies": {
         "query-string": {
-          "version": "6.13.6",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
-          "integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
+          "version": "6.13.8",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
+          "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -10708,7 +10708,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -15049,9 +15050,9 @@
       }
     },
     "js-logger": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/js-logger/-/js-logger-1.6.0.tgz",
-      "integrity": "sha512-K4kt2AdD0jUYINbe00BPPpsL65u/rdYOgfaBBVWm/mid+ANk7qxDnoXgKI5ilm49Sjmach2Dzlc+5VxKdRA3tw=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/js-logger/-/js-logger-1.6.1.tgz",
+      "integrity": "sha512-yTgMCPXVjhmg28CuUH8CKjU+cIKL/G+zTu4Fn4lQxs8mRFH/03QTNvEFngcxfg/gRDiQAOoyCKmMTOm9ayOzXA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -16321,6 +16322,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -16335,6 +16337,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -16344,6 +16347,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -16353,6 +16357,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -16361,7 +16366,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -19698,7 +19704,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shpjs": {
       "version": "3.5.0",
@@ -21853,7 +21860,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
       "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ant-design/icons": "^4.2.2",
     "@brainhubeu/react-carousel": "^1.19.26",
     "@terrestris/base-util": "^0.2.4",
-    "@terrestris/mapfish-print-manager": "^6.2.0",
+    "@terrestris/mapfish-print-manager": "^6.3.1",
     "@terrestris/ol-util": "^4.0.1",
     "@terrestris/react-geo": "^14.1.0",
     "@terrestris/vectortiles": "^0.3.0",

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -518,7 +518,12 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
       map, this.printManager.extentLayer
     );
 
-    return layers.filter((l: any) => legendBlackList.indexOf(l.get('name')) === -1);
+    return layers.filter((l: OlLayer) => legendBlackList.indexOf(l.get('name')) === -1)
+      .map((l: OlLayer) => {
+        l.set('customPrintLegendParams', { 'SCALE': this.state.scale });
+        return l;
+      });
+
   }
 
   /**

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -187,8 +187,11 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
       map: map,
       customPrintScales: printScales,
       timeout: 30000,
-      legendFilter: (layer: any) => this.state.legendIds.includes(layer.ol_uid),
-      layerFilter: (l: any) => !(l instanceof OlLayerGroup) && !printLayerBlackList.includes(l.get('name'))
+      layerFilter: (l: OlLayer) => {
+        const layerName = l.get('name');
+        return layerName && !printLayerBlackList.includes(layerName) &&
+          l.getVisible() && !(l instanceof OlLayerGroup);
+      }
     });
 
     this.printManager = printManager;
@@ -442,6 +445,10 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
     this.printManager.customParams.printScalebar = true;
     this.printManager.customParams.attributions =
       PrintUtil.getAttributions(map, this.printManager.extentLayer);
+
+    // update the legends to be shown
+    this.printManager.legendFilter = (layer: any) => printLegend && legendIds.includes(layer.ol_uid);
+
   };
 
   /**

--- a/src/component/button/PrintButton/PrintButton.tsx
+++ b/src/component/button/PrintButton/PrintButton.tsx
@@ -116,8 +116,14 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
             key="5"
             t={t}
             config={config}
-            legendBlackList={[]}
-            printLayerBlackList={[]}
+            legendBlackList={[
+              'react-geo_measure',
+              'hoverVectorLayer'
+            ]}
+            printLayerBlackList={[
+              'react-geo_measure',
+              'hoverVectorLayer'
+            ]}
             printScales={printScales}
           />
         </Window>

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -254,11 +254,14 @@ class AppContextUtil {
       params: {
         'LAYERS': layerNames,
         'TILED': requestWithTiled || false,
-        'TRANSPARENT': true,
-        'TIME': type === 'WMSTime' ? moment(moment.now()).format(defaultFormat) : undefined
+        'TRANSPARENT': true
       },
       crossOrigin: crossOrigin
     });
+
+    if (type === 'WMSTime') {
+      layerSource.getParams().TIME = moment(moment.now()).format(defaultFormat);
+    }
 
     const tileLayer = new OlTileLayer({
       source: layerSource,


### PR DESCRIPTION
* Update [@terrestris/mapfish-print-manager](https://github.com/terrestris/mapfish-print-manager) package to `v6.3.1` to enable handling of static legend images as well WMTS layer serialization
* Fix broken legend images for non time based layer which will be declared with invalid parameter `TIME=undefined`
* Add some common blacklisted layers for print like `hoverVectorlayer` and always kick them from print
* Fix legend and layer filter set on mapfish print provider￼
* Consider `SCALE` parameter by legend graphics to avoid possibly dublicated legend rules.

Please review @terrestris/devs 