### PR TITLE
Fixup responsive design of header and footer

### DIFF
--- a/src/component/container/Footer/Footer.css
+++ b/src/component/container/Footer/Footer.css
@@ -1,4 +1,5 @@
 .footer {
+  display: flex;
   height: var(--footer-height);
 }
 
@@ -7,10 +8,33 @@
   display: flex;
   padding: 0px 5px 0px 5px;
   align-items: center;
+  white-space: nowrap;
+}
+
+.footer .crscombo-col {
+  padding-left: 5px;
+}
+
+.footer .crscombo-col > span {
+  padding-right: 5px;
+}
+
+.footer .crscombo-col .react-geo-coordinatereferencesystemcombo {
+  min-width: 60px;
+}
+
+.crs-dropdown {
+  min-width: 250px !important;
+}
+
+@media only screen and (max-width: 900px) {
+  .footer .crscombo-col {
+    display: none;
+  }
 }
 
 .footer .scalecombo-col {
-    float: left;
+  float: left;
 }
 
 .footer .scalecombo-col > span {
@@ -21,31 +45,13 @@
   width: 150px !important;
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 500px) {
   .footer .scalecombo-col {
     display: none;
   }
 }
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 500px) {
   .footer .scalecombo-col .scalecombo {
-    display: none;
-  }
-}
-
-.footer .crscombo-col {
-    padding-left: 5px;
-}
-
-.footer .crscombo-col > span {
-  padding-right: 5px;
-}
-
-.footer .crscombo-col .react-geo-coordinatereferencesystemcombo {
-  width: 50%;
-}
-
-@media only screen and (max-width: 768px) {
-  .footer .crscombo-col {
     display: none;
   }
 }
@@ -55,6 +61,10 @@
   right: 0;
   position: inherit;
   padding-left: 5px;
+  justify-content: flex-start;
+  margin-right: 5px;
+  min-width: 250px;
+  width: 100%;
 }
 
 @media only screen and (max-width: 768px) {
@@ -63,24 +73,17 @@
   }
 }
 
-.footer .imprint {
-    justify-content: center;
-}
-
-@media only screen and (max-width: 768px) {
+@media only screen and (min-width: 500px) {
   .footer .imprint {
     width: 100%;
-    float: right;
+    justify-content: flex-end;
+    padding-right: 10px;
   }
 }
 
-.footer #mouse-position {
-  justify-content: flex-start;
-  margin-right: 5px;
-}
-
-@media only screen and (max-width: 768px) {
-  .footer #mouse-position {
-    display: none;
+@media only screen and (max-width: 500px) {
+  .footer .imprint {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -4,10 +4,6 @@ import { connect } from 'react-redux';
 import './Footer.css';
 
 import {
-  Row,
-  Col
-} from 'antd';
-import {
   get as getProjection,
   getTransform
 } from 'ol/proj.js';
@@ -203,51 +199,35 @@ export class Footer extends React.Component<FooterProps, FooterState> {
 
     return (
       <footer className="footer">
-        <Row>
-          <Col
-            className="crscombo-col footer-element"
-            span={6}
+        <div className="crscombo-col footer-element">
+          <span>{t('CoordinateReferenceSystemCombo.label')}</span>
+          <CoordinateReferenceSystemCombo
+            allowClear={false}
+            dropdownClassName="crs-dropdown"
+            predefinedCrsDefinitions={this.predefinedCrsDefinitions}
+            onSelect={this.setProjection}
+            emptyTextPlaceholderText={t('CoordinateReferenceSystemCombo.emptyTextPlaceholderText') as string}
+            value={projection.replace('EPSG:', '')}
+          />
+        </div>
+        <div className="scalecombo-col footer-element">
+          <span>{t('ScaleComboLabel')}</span>
+          <ScaleCombo
+            className="scalecombo"
+            map={map}
+            scales={mapScales}
+          />
+        </div>
+        <div className="ol-mouse-position footer-element">
+          <span>{t('MousePositionLabel')}: </span>
+          <div id="mouse-position"/>
+        </div>
+        <div className="imprint footer-element">
+          <a
+            href={imprintLink ? imprintLink : 'https://www.terrestris.de/en/impressum'}
           >
-            <span>{t('CoordinateReferenceSystemCombo.label')}</span>
-            <CoordinateReferenceSystemCombo
-              allowClear={false}
-              predefinedCrsDefinitions={this.predefinedCrsDefinitions}
-              onSelect={this.setProjection}
-              emptyTextPlaceholderText={t('CoordinateReferenceSystemCombo.emptyTextPlaceholderText') as string}
-              value={projection.replace('EPSG:', '')}
-            />
-          </Col>
-          <Col
-            className="scalecombo-col footer-element"
-            span={4}
-          >
-            <span>{t('ScaleComboLabel')}</span>
-            <ScaleCombo
-              className="scalecombo"
-              map={map}
-              scales={mapScales}
-            />
-          </Col>
-          <Col
-            span={8}
-            className="ol-mouse-position footer-element"
-          >
-            <span>{t('MousePositionLabel')}: </span>
-            <div id="mouse-position"/>
-          </Col>
-          <Col span={2}>
-            <div />
-          </Col>
-          <Col
-            span={4}
-            className="imprint footer-element"
-          >
-            <a
-              href={imprintLink ? imprintLink : 'https://www.terrestris.de/en/impressum'}
-            >
-              {imprintText ? imprintText : `${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>
-          </Col>
-        </Row>
+            {imprintText ? imprintText : `${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>
+        </div>
       </footer>
     );
   }

--- a/src/component/container/Header/Header.css
+++ b/src/component/container/Header/Header.css
@@ -1,42 +1,39 @@
 .app-header {
   border-bottom: 1px solid lightgray;
   background-color: var(--toolbarColor);
-}
-
-.app-header .ant-row {
-  width: 100%;
-}
-
-.app-header .ant-row .ant-col{
   height: var(--header-height);
   display: flex;
-  justify-content: center;
   align-items: center;
+}
+
+.app-header .app-loading-indicator {
+  max-width: 150px;
+  position: relative;
+  padding: 0 5px 0 5px;
+  display: block !important;
+}
+@media screen and (max-width: 576px) {
+  .app-header .app-loading-indicator {
+    display: none !important;;
+  }
 }
 
 .app-header .logo .app-logo {
   height: calc(var(--header-height) - 10px);
+  padding-right: 5px;
 }
 .app-header .logo .app-logo.with-link:hover {
   cursor: pointer;
 }
-@media screen and (max-width: 1500px) {
-  .app-header .logo {
-    display: none;
-  }
-}
 
-.app-header .react-geo-nominatimsearch {
+.app-header .search {
   width: 100%;
+  justify-content: center;
+  display: flex;
 }
 
-.app-header .app-language-selection {
-  display: block;
-  width: 42px;
-}
-
-.app-header .app-language-selection > img {
-  padding-right: 5px;
+.app-header .search .react-geo-nominatimsearch {
+  max-width: 500px;
 }
 
 .app-header .app-title {
@@ -44,4 +41,22 @@
   font-weight: bold;
   font-size: 20px;
   color: var(--textColor);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 150px;
+}
+
+@media screen and (max-width: 576px) {
+  .app-header .app-title {
+    display: none;
+  }
+}
+
+.app-header .app-language-selection {
+  display: flex;
+}
+
+.app-header .app-language-selection > img {
+  padding: 0 5px 0 5px;
+  cursor: pointer;
 }

--- a/src/component/container/Header/Header.tsx
+++ b/src/component/container/Header/Header.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {
-  Spin,
-  Row,
-  Col
+  Spin
 } from 'antd';
 
 import NominatimSearch from '@terrestris/react-geo/dist/Field/NominatimSearch/NominatimSearch';
@@ -105,93 +103,51 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     }
 
     return (
-      <header className={className}>
-        <Row>
-          <Col
-            xs={1}
-            sm={1}
-            md={1}
-            lg={1}
-          >
-            <Spin
-              spinning={loading}
-              className="app-loading-indicator"
-            />
-          </Col>
-          <Col
-            xs={0}
-            sm={0}
-            md={6}
-            lg={6}
-          >
-            <div className="logo">
-              {
-                logoConfig ? logoConfig.map((config, idx) =>
-                  <img
-                    src={config.src}
-                    key={`logo-${idx}`}
-                    alt={config.target}
-                    className={config.target ? 'app-logo with-link' : 'app-logo'}
-                    onClick={config.target ? () => window.open(config.target, '_blank') : () => {}}
-                  />
-                )
-                  : null}
-            </div>
-          </Col>
-          <Col
-            xs={10}
-            sm={10}
-            md={6}
-            lg={6}
-          >
-            <NominatimSearch
-              placeholder={t('Header.nominatimPlaceHolder')}
-              countrycodes={''}
-              map={map}
-              style={{
-                width: '100%'
-              }}
-            />
-          </Col>
-          <Col
-            xs={0}
-            sm={0}
-            md={6}
-            lg={6}
-          >
-            <span className="app-title">{titleString}</span>
-          </Col>
-          <Col
-            xs={1}
-            sm={1}
-            md={3}
-            lg={3}
-          >
-            {showHelpButton &&
-            <SimpleButton
-              name="helpButtonModule"
-              iconName="fas fa-question"
-              shape="circle"
-              tooltip={t('Header.helpButtonTooltip') as string}
-              onClick={this.onHelpButtonClick}
-              tooltipPlacement={'bottom'}
-            />
-            }
-          </Col>
-          <Col
-            xs={1}
-            sm={1}
-            md={2}
-            lg={2}
-          >
-            {showLanguageSelection &&
-              <div className="app-language-selection">
-                <img src="de.png" alt="DE" onClick={() => this.onLanguageChange('de')} />
-                <img src="en.png" alt="EN" onClick={() => this.onLanguageChange('en')} />
-              </div>
-            }
-          </Col>
-        </Row>
+      <header className={'app-header ' + className}>
+        <Spin
+          spinning={loading}
+          className="app-loading-indicator"
+        />
+        <div className="logo">
+          {
+            logoConfig ? logoConfig.map((config, idx) =>
+              <img
+                src={config.src}
+                key={`logo-${idx}`}
+                alt={config.target}
+                className={config.target ? 'app-logo with-link' : 'app-logo'}
+                onClick={config.target ? () => window.open(config.target, '_blank') : () => {}}
+              />
+            )
+              : null}
+        </div>
+        <div className="search">
+          <NominatimSearch
+            placeholder={t('Header.nominatimPlaceHolder')}
+            countrycodes={''}
+            map={map}
+            style={{
+              width: '100%'
+            }}
+          />
+        </div>
+        <span className="app-title">{titleString}</span>
+        {showHelpButton &&
+        <SimpleButton
+          name="helpButtonModule"
+          iconName="fas fa-question"
+          shape="circle"
+          tooltip={t('Header.helpButtonTooltip') as string}
+          onClick={this.onHelpButtonClick}
+          tooltipPlacement={'bottom'}
+        />
+        }
+        {showLanguageSelection &&
+        <div className="app-language-selection">
+          <img src="de.png" alt="DE" onClick={() => this.onLanguageChange('de')} />
+          <img src="en.png" alt="EN" onClick={() => this.onLanguageChange('en')} />
+        </div>
+        }
       </header>
     );
   }


### PR DESCRIPTION
This removes the unusable antd bootstrap like grid and replaces it with css media queries.
Components are now ordered and displayed fine in responsive mode.

@terrestris/devs please review
