### PR TITLE
zoomToExtentButton: use center and zoom for extent definition

### DIFF
--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -423,12 +423,11 @@ class AppContextUtil {
           return;
         case 'shogun-button-zoomtoextent':
           tools.push(<ZoomToExtentButton
-            extent={[
-              mapConfig.extent.lowerLeft.x,
-              mapConfig.extent.lowerLeft.y,
-              mapConfig.extent.upperRight.x,
-              mapConfig.extent.upperRight.y
+            center={[
+              mapConfig.center.x,
+              mapConfig.center.y
             ]}
+            zoom={mapConfig.zoom}
             map={map}
             key="3"
             type="primary"


### PR DESCRIPTION
Make use of `center` and `zoom` instead of `extent`, since this is more flexible and also already part of the shogun appContext.

@terrestris/devs please review.