### PR TITLE
Enhance imprint display in footer

### DIFF
--- a/src/ProjectMain.tsx
+++ b/src/ProjectMain.tsx
@@ -180,6 +180,7 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
           map={map}
           t={t}
           mapScales={mapScales}
+          imprint={appContext.imprint}
         />
       </div>
     );

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -220,13 +220,14 @@ export class Footer extends React.Component<FooterProps, FooterState> {
           <span>{t('MousePositionLabel')}: </span>
           <div id="mouse-position"/>
         </div>
-        {imprint &&
-          <div className="footer footer-element">
-            {imprint ? <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
-              <a href="https://www.terrestris.de/de/impressum">
-                {`${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>}
-          </div>
+        <div className="footer footer-element">
+        {imprint ?
+          <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
+            <a href="https://www.terrestris.de/de/impressum">
+              {`${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}
+            </a>
         }
+        </div>
       </footer>
     );
   }

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -20,8 +20,7 @@ import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 // default props
 interface DefaultFooterProps {
-  imprintLink: string;
-  imprintText: string;
+  imprint: string;
 }
 
 interface FooterProps extends Partial<DefaultFooterProps>{
@@ -192,8 +191,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
       map,
       mapScales,
       projection,
-      imprintLink,
-      imprintText,
+      imprint,
       t
     } = this.props;
 
@@ -222,12 +220,13 @@ export class Footer extends React.Component<FooterProps, FooterState> {
           <span>{t('MousePositionLabel')}: </span>
           <div id="mouse-position"/>
         </div>
-        <div className="imprint footer-element">
-          <a
-            href={imprintLink ? imprintLink : 'https://www.terrestris.de/en/impressum'}
-          >
-            {imprintText ? imprintText : `${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>
-        </div>
+        {imprint &&
+          <div className="footer footer-element">
+            {imprint ? <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
+            <a href="https://www.terrestris.de/de/impressum">
+              {`${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>}
+          </div>
+        }
       </footer>
     );
   }

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -220,7 +220,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
           <span>{t('MousePositionLabel')}: </span>
           <div id="mouse-position"/>
         </div>
-        <div className="footer footer-element">
+        <div className="imprint footer-element">
         {imprint ?
           <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
             <a href="https://www.terrestris.de/de/impressum">

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -221,12 +221,12 @@ export class Footer extends React.Component<FooterProps, FooterState> {
           <div id="mouse-position"/>
         </div>
         <div className="imprint footer-element">
-        {imprint ?
-          <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
+          {imprint ?
+            <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
             <a href="https://www.terrestris.de/de/impressum">
               {`${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}
             </a>
-        }
+          }
         </div>
       </footer>
     );

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -223,8 +223,8 @@ export class Footer extends React.Component<FooterProps, FooterState> {
         {imprint &&
           <div className="footer footer-element">
             {imprint ? <div dangerouslySetInnerHTML={{ __html: imprint }} /> :
-            <a href="https://www.terrestris.de/de/impressum">
-              {`${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>}
+              <a href="https://www.terrestris.de/de/impressum">
+                {`${t('Imprint.title')} / ${t('Imprint.privacypolicy')}`}</a>}
           </div>
         }
       </footer>

--- a/src/resources/appContext.json
+++ b/src/resources/appContext.json
@@ -8,6 +8,7 @@
 	"open": true,
 	"active": true,
 	"url": null,
+	"imprint": "<a href='https://www.terrestris.de/en/impressum'>Imprint / Privacy</a>",
 	"viewport": {
 		"id": 62,
 		"name": "Viewport with Border Layout",


### PR DESCRIPTION
Enable handling of `imprint` strings containing html within footer.  
Not sure, if this should better be an extra prop like `imprintHTML` and keep the others?
Background idea is to improve the configuration of custom imprint for users.

@terrestris/devs please review.