### PR TITLE
Adding Multisearch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2964,9 +2964,9 @@
       }
     },
     "@terrestris/react-geo": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/@terrestris/react-geo/-/react-geo-14.2.2.tgz",
-      "integrity": "sha512-GstZrZZtXNQ0fEUvykPBrpsah8Fro+cSKvZBlJMuTif7KPEpL+wEkoysPzrwVJqxQeRMJGO53K0Kvx6a0Jaceg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/react-geo/-/react-geo-14.2.3.tgz",
+      "integrity": "sha512-nLND4ZRP6YJjd88GodwIKAxuH6uZcRIS+X2JAvczg84FTlvf1nHKTWJzTk4ph4PokxbAAhVrrFxdV8WiToCHVg==",
       "requires": {
         "@ag-grid-community/client-side-row-model": "^23.2.1",
         "@ag-grid-community/core": "^23.2.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@terrestris/base-util": "^0.2.4",
     "@terrestris/mapfish-print-manager": "^6.3.3",
     "@terrestris/ol-util": "^4.0.1",
-    "@terrestris/react-geo": "^14.2.2",
+    "@terrestris/react-geo": "^14.2.3",
     "@terrestris/vectortiles": "^0.3.0",
     "antd": "^4.6.4",
     "es-abstract": "^1.18.0-next.0",

--- a/src/component/Multisearch/Multisearch.css
+++ b/src/component/Multisearch/Multisearch.css
@@ -1,0 +1,30 @@
+.multisearch .ant-select {
+    min-width: 300px;
+    max-width: 500px;
+}
+
+.multi-search-result-layer-title {
+    font-weight: bold;
+    font-size: 1.2em;
+    font-style: oblique;
+}
+
+.multi-search-result-layer-title > div {
+    float: right;
+    font-weight: bold;
+}
+
+.multi-search-result-entry {
+    display: flex;
+    justify-content: space-between;
+}
+
+.multisearch .loader {
+    margin-left: -50px;
+    padding-top: 5px;
+    z-index: 0;
+}
+
+.multisearch .loader.hidden {
+    z-index: -1;
+}

--- a/src/component/Multisearch/Multisearch.tsx
+++ b/src/component/Multisearch/Multisearch.tsx
@@ -1,0 +1,347 @@
+import * as React from 'react';
+
+import { WfsSearchInput, NominatimSearch } from '@terrestris/react-geo';
+
+import './Multisearch.css';
+import { AutoComplete } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
+
+import { transformExtent } from 'ol/proj';
+import OlFormatGeoJSON from 'ol/format/GeoJSON';
+import OlLayer from 'ol/layer/Base';
+
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
+// default props
+interface DefaultMultisearchProps {
+  className: string;
+  useNominatim: boolean;
+  useWfs: boolean;
+  minChars: number;
+  nominatimSearchTitle: string;
+  placeHolder: string;
+}
+
+interface MultisearchProps extends Partial<DefaultMultisearchProps> {
+  map: any;
+}
+
+interface MultisearchState {
+  searchTerm: string;
+  wfsResults: any[];
+  wfsFeatures: any[];
+  nominatimResults: any[];
+  nominatimFeatures: any[];
+  fetching: boolean;
+  options: any[];
+  searchAttributes: any;
+  searchConfig: any;
+  wfsSearchPending: boolean;
+  nominatimSearchPending: boolean;
+}
+
+/**
+ * Class representing the Multisearch.
+ *
+ * @class Multisearch
+ * @extends React.Component
+ */
+export default class Multisearch extends
+  React.Component<MultisearchProps, MultisearchState> {
+
+  public static defaultProps: DefaultMultisearchProps = {
+    className: 'multisearch',
+    useNominatim: true,
+    useWfs: true,
+    minChars: 3,
+    nominatimSearchTitle: 'Nominatim',
+    placeHolder: 'search location or data'
+  };
+
+  /**
+   * Create the Multisearch.
+   *
+   * @constructs Multisearch
+   */
+  constructor(props: MultisearchProps) {
+    super(props);
+
+    const searchLayers = MapUtil.getLayersByProperty(
+      this.props.map, 'searchable', true);
+    const searchConfig = {};
+    const searchAttributes = {};
+    searchLayers.forEach((l: OlLayer) => {
+      const conf = l.get('searchConfig');
+      if (conf) {
+        searchConfig[conf.featureTypeName] = conf;
+        searchAttributes[conf.featureTypeName] = conf.attributes;
+      }
+    });
+
+    this.state = {
+      searchTerm: '',
+      wfsResults: [],
+      wfsFeatures: [],
+      nominatimResults: [],
+      nominatimFeatures: [],
+      fetching: false,
+      options: [],
+      searchConfig,
+      searchAttributes,
+      wfsSearchPending: false,
+      nominatimSearchPending: false
+    };
+  }
+
+  renderTitle(title: string, count: number) {
+    return (
+      <span className='multi-search-result-layer-title'>
+        {title}
+        <div>{count}</div>
+      </span>
+    );
+  }
+
+  renderItem(title: string, nominatimFeature: any, wfsFeature: any) {
+    return {
+      value: title,
+      key: Math.random(),
+      nominatimfeatureid: nominatimFeature ? nominatimFeature.osm_id : null,
+      wfsfeatureid: wfsFeature ? wfsFeature.id : null,
+      label: (
+        <div className='multi-search-result-entry'>
+          {title}
+        </div>
+      ),
+    };
+  }
+
+  onNominatimSearchSuccess(data: any) {
+    this.setState({
+      fetching: this.props.useWfs && this.state.wfsSearchPending,
+      nominatimSearchPending: false,
+      nominatimFeatures: data,
+      nominatimResults: [{
+        label: this.renderTitle(this.props.nominatimSearchTitle, data.length),
+        options: data.map((el: any) => this.renderItem(
+          el.display_name, el, null))
+      }]
+    });
+  }
+
+  wfsSearchSuccess(data: any) {
+    const results = {};
+    data.forEach((el: any) => {
+      const ft = el.id.substring(0, el.id.lastIndexOf('.'));
+      results[ft] = {
+        features: [],
+        count: 0
+      };
+    });
+    data.forEach((el: any) => {
+      const ft = el.id.substring(0, el.id.lastIndexOf('.'));
+      results[ft].features.push(el);
+      results[ft].count++;
+    });
+    Object.keys(results).map((key) => {
+      const searchLayers = MapUtil.getLayersByProperty(
+        this.props.map, 'searchable', true);
+      searchLayers.forEach((l: any) => {
+        const config = l.get('searchConfig');
+        if (config && config.featureTypeName &&
+            config.featureTypeName.indexOf(key) > -1) {
+          results[key].title = l.get('name');
+        }
+      });
+    });
+
+    const wfsResults = Object.keys(results).map((key) => {
+      return {
+        label: this.renderTitle(results[key].title, results[key].count),
+        options: results[key].features.map((f: any) => {
+          const ft = f.id.substring(0, f.id.lastIndexOf('.'));
+          const config: any = Object.keys(this.state.searchConfig).
+            find(fqft => {
+              let unqualifiedFeatureType = fqft;
+              if (unqualifiedFeatureType.indexOf(':') > 0) {
+                unqualifiedFeatureType = unqualifiedFeatureType.split(':')[1];
+              }
+              if (unqualifiedFeatureType === ft) {
+                return true;
+              }
+              return false;
+            });
+          let title = '';
+          if (config && this.state.searchConfig[config].displayTemplate) {
+            let attr = this.state.searchConfig[config].displayTemplate;
+            attr = attr.match(/\{(.*?)\}/g).map((el: any) => el.replaceAll(
+              '{', '').replaceAll('}', ''));
+            attr.forEach((prop: any) => {
+              title += f.properties[prop];
+            });
+          } else {
+            title = f.properties[Object.keys(f.properties)[0]];
+          }
+          return this.renderItem(title, null, f);
+        })
+      };
+    });
+    this.setState({
+      fetching: this.props.useNominatim && this.state.nominatimSearchPending,
+      wfsSearchPending: false,
+      wfsFeatures: data,
+      wfsResults
+    });
+  }
+
+  onFetchError() {
+    this.setState({
+      nominatimResults: [],
+      nominatimFeatures: [],
+      wfsResults: [],
+      wfsFeatures: [],
+      fetching: false,
+      wfsSearchPending: false,
+      nominatimSearchPending: false
+    });
+  }
+
+  onUpdateInput(val: string) {
+    const fetching = val && val !== '' && val.length >= this.props.minChars;
+    this.setState({
+      searchTerm: val,
+      fetching,
+      wfsSearchPending: fetching && this.props.useWfs,
+      nominatimSearchPending: fetching && this.props.useNominatim
+    });
+  }
+
+  resetSearch() {
+    this.setState({
+      searchTerm: '',
+      nominatimResults: [],
+      nominatimFeatures: [],
+      wfsResults: [],
+      wfsFeatures: [],
+      fetching: false,
+      wfsSearchPending: false,
+      nominatimSearchPending: false
+    });
+  }
+
+  onSelect(text: string, selection: any) {
+    let feature: any;
+    if (selection.nominatimfeatureid) {
+      feature = this.state.nominatimFeatures.find(
+        el => el.osm_id === selection.nominatimfeatureid);
+      const olView = this.props.map.getView();
+      let extent = [
+        feature.boundingbox[2],
+        feature.boundingbox[0],
+        feature.boundingbox[3],
+        feature.boundingbox[1]
+      ];
+
+      extent = extent.map(function(coord: string) {
+        return parseFloat(coord);
+      });
+
+      extent = transformExtent(extent, 'EPSG:4326',
+        olView.getProjection().getCode());
+
+      olView.fit(extent, {
+        duration: 500
+      });
+      return;
+    } else {
+      feature = this.state.wfsFeatures.find(
+        el => el.id === selection.wfsfeatureid);
+      const olView = this.props.map.getView();
+      const geoJsonFormat = new OlFormatGeoJSON();
+      const olFeature = geoJsonFormat.readFeature(feature);
+      const geometry = olFeature.getGeometry();
+
+      if (geometry) {
+        olView.fit(geometry, {
+          duration: 500
+        });
+      }
+
+      // make layer visible
+      const searchLayers = MapUtil.getLayersByProperty(
+        this.props.map, 'searchable', true);
+      const layer = searchLayers.find((l: any) =>
+        l.get('searchConfig').featureTypeName.indexOf(
+          feature.id.split('.')[0]) > -1);
+      if (layer && !layer.getVisible()) {
+        layer.setVisible(true);
+      }
+    }
+  }
+
+  /**
+   * The render function
+   */
+  render() {
+    const {
+      map,
+      className,
+      useNominatim,
+      useWfs,
+      minChars,
+      placeHolder
+    } = this.props;
+
+    const {
+      searchTerm,
+      wfsResults,
+      nominatimResults,
+      searchAttributes,
+      searchConfig,
+      fetching
+    } = this.state;
+
+    return (
+      <div className={'multisearch ' + className}>
+        <AutoComplete
+          allowClear={true}
+          dropdownMatchSelectWidth={500}
+          onChange={this.onUpdateInput.bind(this)}
+          onSearch={this.onUpdateInput.bind(this)}
+          options={nominatimResults.concat(wfsResults)}
+          onSelect={this.onSelect.bind(this)}
+          onClear={this.resetSearch.bind(this)}
+          placeholder={placeHolder}
+        >
+        </AutoComplete>
+        <div className={`loader ${fetching ? 'active' : 'hidden'}`}>
+          <LoadingOutlined />
+        </div>
+        {useNominatim &&
+            <NominatimSearch
+              countrycodes={''}
+              map={map}
+              minChars={minChars}
+              visible={false}
+              searchTerm={searchTerm}
+              onFetchSuccess={this.onNominatimSearchSuccess.bind(this)}
+              onFetchError={this.onFetchError.bind(this)}
+            />
+        }
+        {useWfs &&
+           <WfsSearchInput
+             map={map}
+             minChars={minChars}
+             baseUrl='/geoserver.action'
+             featureTypes={Object.keys(searchConfig)}
+             onFetchSuccess={this.wfsSearchSuccess.bind(this)}
+             onFetchError={this.onFetchError.bind(this)}
+             searchAttributes={searchAttributes}
+             visible={false}
+             searchTerm={searchTerm}
+           />
+        }
+      </div>
+    );
+  }
+}

--- a/src/component/container/Header/Header.css
+++ b/src/component/container/Header/Header.css
@@ -36,6 +36,12 @@
   max-width: 500px;
 }
 
+.app-header .multisearch {
+  width: 100%;
+  justify-content: center;
+  display: flex;
+}
+
 .app-header .app-title {
   text-align: center;
   font-weight: bold;

--- a/src/component/container/Header/Header.tsx
+++ b/src/component/container/Header/Header.tsx
@@ -3,12 +3,12 @@ import {
   Spin
 } from 'antd';
 
-import NominatimSearch from '@terrestris/react-geo/dist/Field/NominatimSearch/NominatimSearch';
 import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 import { toggleHelpModal } from '../../../state/actions/AppStateAction';
 
 import './Header.css';
+import Multisearch from '../../../component/Multisearch/Multisearch';
 
 type LogoConfig = {
   src: string;
@@ -23,6 +23,8 @@ interface DefaultHeaderProps {
   logoConfig: LogoConfig[];
   showHelpButton: boolean;
   showLanguageSelection: boolean;
+  showMultiSearch: boolean;
+  showNominatimSearch: boolean;
 }
 
 interface HeaderProps extends Partial<DefaultHeaderProps> {
@@ -50,7 +52,9 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     loading: false,
     logoConfig: undefined,
     showHelpButton: false,
-    showLanguageSelection: true
+    showLanguageSelection: true,
+    showMultiSearch: true,
+    showNominatimSearch: true
   };
 
   /**
@@ -94,6 +98,8 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
       logoConfig,
       showHelpButton,
       showLanguageSelection,
+      showMultiSearch,
+      showNominatimSearch,
       t
     } = this.props;
 
@@ -121,16 +127,15 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
             )
               : null}
         </div>
-        <div className="search">
-          <NominatimSearch
-            placeholder={t('Header.nominatimPlaceHolder')}
-            countrycodes={''}
+        {showMultiSearch &&
+          <Multisearch
             map={map}
-            style={{
-              width: '100%'
-            }}
+            useNominatim={showNominatimSearch}
+            useWfs={true}
+            nominatimSearchTitle={t('Multisearch.nominatimSearchTitle') as string}
+            placeHolder={t('Multisearch.placeHolder') as string}
           />
-        </div>
+        }
         <span className="app-title">{titleString}</span>
         {showHelpButton &&
         <SimpleButton

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -134,6 +134,10 @@
       "extent": "Geographische Ausdehnung"
     }
   },
+  "Multisearch": {
+    "placeHolder": "Orte und Daten suchen",
+    "nominatimSearchTitle": "Ortssuche"
+  },
   "LayerTreeDropdownContextMenu": {
     "layerInfoText": "Layerbeschreibung",
     "layerSettingsTooltipText": "Eigenschaften",

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -134,6 +134,10 @@
       "extent": "Geographical Extent"
     }
   },
+  "Multisearch": {
+    "placeHolder": "Search location or data",
+    "nominatimSearchTitle": "Location search"
+  },
   "LayerTreeDropdownContextMenu": {
     "layerInfoText": "Layer description",
     "layerSettingsTooltipText": "Properties",

--- a/src/util/AppContextUtil.tsx
+++ b/src/util/AppContextUtil.tsx
@@ -214,6 +214,8 @@ class AppContextUtil {
         tileLayer.set('columnAliasesDe', layerObj.columnAliasesDe);
         tileLayer.set('columnAliasesEn', layerObj.columnAliasesEn);
         tileLayer.set('legendUrl', layerObj.legendUrl);
+        tileLayer.set('searchable', layerObj.searchable);
+        tileLayer.set('searchConfig', layerObj.searchConfig);
         layers.push(tileLayer);
         return;
       }
@@ -319,6 +321,8 @@ class AppContextUtil {
     tileLayer.set('columnAliasesDe', layerObj.columnAliasesDe);
     tileLayer.set('columnAliasesEn', layerObj.columnAliasesEn);
     tileLayer.set('legendUrl', layerObj.legendUrl);
+    tileLayer.set('searchable', layerObj.searchable);
+    tileLayer.set('searchConfig', layerObj.searchConfig);
 
     if (type === 'WMSTime') {
       const startDate = layerObj.startDate ? moment(layerObj.startDate).format(defaultFormat) : undefined;
@@ -386,6 +390,8 @@ class AppContextUtil {
     imageLayer.set('columnAliasesDe', layerObj.columnAliasesDe);
     imageLayer.set('columnAliasesEn', layerObj.columnAliasesEn);
     imageLayer.set('legendUrl', layerObj.legendUrl);
+    imageLayer.set('searchable', layerObj.searchable);
+    imageLayer.set('searchConfig', layerObj.searchConfig);
 
     return imageLayer;
   }


### PR DESCRIPTION
This adds a multisearch that combines the Nominatim and WFS search from react-geo.

![image](https://user-images.githubusercontent.com/1381363/104576783-f0ae5600-5658-11eb-9044-afb8fd7d057d.png)


It respects the configuration from the appcontext:
  - if the multisearch should be used at all
  - if the nominatimsearch is active
  - only search in layers that are configured accordingly
  - only search in specified attributes of configured layers

@terrestris/devs please review
