### PR TITLE
Adjust print window for mobile

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -35,3 +35,10 @@ div.imprint.footer-element {
 button, .ant-collapse-header, .react-geo-titlebar {
   background-color: var(--baseColor) !important;
 }
+
+@media only screen and (max-width: 768px) {
+  .react-geo-panel {
+      width: 100% !important;
+      transform: translate(0, 100px) !important;
+  }
+}

--- a/src/component/PrintPanel/PrintPanelV3.css
+++ b/src/component/PrintPanel/PrintPanelV3.css
@@ -96,6 +96,6 @@
 @media only screen and (max-width: 768px) {
   /* hide print preview for mobile clients */
   .preview-card-col, .preview-button {
-    display: none;
+    display: none !important;
   }
 }

--- a/src/component/PrintPanel/PrintPanelV3.css
+++ b/src/component/PrintPanel/PrintPanelV3.css
@@ -92,3 +92,10 @@
 .print-panel span.react-geo-simplebutton {
   background-color: transparent;
 }
+
+@media only screen and (max-width: 768px) {
+  /* hide print preview for mobile clients */
+  .preview-card-col, .preview-button {
+    display: none;
+  }
+}

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -632,7 +632,7 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
         >
           {/* preview column */}
           <Col
-            span={12}
+            flex={1}
             className={'preview-card-col'}
           >
             <Card className='preview-card'>
@@ -648,7 +648,7 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
           </Col>
           {/* settings column */}
           <Col
-            span={12}
+            flex={2}
           >
             {/* title and description */}
             <div className="wrapper-settings-col">

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -27,6 +27,7 @@ import OlLayer from 'ol/layer/Layer';
 import { MapFishPrintV3Manager } from '@terrestris/mapfish-print-manager';
 
 import PrintUtil from '../../util/PrintUtil/PrintUtil';
+import DeviceDetector from '../../util/DeviceDetector';
 
 import './PrintPanelV3.css';
 
@@ -625,24 +626,29 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
 
     const printDisabled = !outputFormat || !dpi || !scale || !layout;
 
+    const isMobile = DeviceDetector.isMobileDevice();
+    
     return (
       <div className="print-panel">
         <Row
           gutter={5}
         >
           {/* preview column */}
-          <Col span={12}>
-            <Card className="preview-card">
-              <span>{t('PrintPanel.previewCardTitle')}</span>
-              {
-                loadingPreview ? <Skeleton active={true} /> :
-                  <img
-                    alt="preview"
-                    src={previewUrl}
-                  />
-              }
-            </Card>
-          </Col>
+           {
+              !isMobile ?
+                <Col span={12}>
+                  <Card className="preview-card">
+                    <span>{t('PrintPanel.previewCardTitle')}</span>
+                    {
+                      loadingPreview ? <Skeleton active={true} /> :
+                        <img
+                          alt="preview"
+                          src={previewUrl}
+                        />
+                    }
+                  </Card>
+                </Col> : null 
+            }
           {/* settings column */}
           <Col
             span={12}
@@ -740,6 +746,7 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
         </Row>
         <Titlebar tools={[
           <SimpleButton
+            hidden={isMobile}
             size="small"
             key="preview-button"
             type="primary"

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -648,7 +648,7 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
           </Col>
           {/* settings column */}
           <Col
-            flex={2}
+            flex={1}
           >
             {/* title and description */}
             <div className="wrapper-settings-col">

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -27,7 +27,6 @@ import OlLayer from 'ol/layer/Layer';
 import { MapFishPrintV3Manager } from '@terrestris/mapfish-print-manager';
 
 import PrintUtil from '../../util/PrintUtil/PrintUtil';
-import DeviceDetector from '../../util/DeviceDetector';
 
 import './PrintPanelV3.css';
 
@@ -626,29 +625,27 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
 
     const printDisabled = !outputFormat || !dpi || !scale || !layout;
 
-    const isMobile = DeviceDetector.isMobileDevice();
-    
     return (
       <div className="print-panel">
         <Row
           gutter={5}
         >
           {/* preview column */}
-           {
-              !isMobile ?
-                <Col span={12}>
-                  <Card className="preview-card">
-                    <span>{t('PrintPanel.previewCardTitle')}</span>
-                    {
-                      loadingPreview ? <Skeleton active={true} /> :
-                        <img
-                          alt="preview"
-                          src={previewUrl}
-                        />
-                    }
-                  </Card>
-                </Col> : null 
-            }
+          <Col
+            span={12}
+            className={'preview-card-col'}
+          >
+            <Card className='preview-card'>
+              <span>{t('PrintPanel.previewCardTitle')}</span>
+              {
+                loadingPreview ? <Skeleton active={true} /> :
+                  <img
+                    alt="preview"
+                    src={previewUrl}
+                  />
+              }
+            </Card>
+          </Col>
           {/* settings column */}
           <Col
             span={12}
@@ -746,9 +743,9 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
         </Row>
         <Titlebar tools={[
           <SimpleButton
-            hidden={isMobile}
             size="small"
             key="preview-button"
+            className="preview-button"
             type="primary"
             loading={loadingPreview}
             disabled={printDisabled}

--- a/src/component/button/PrintButton/PrintButton.tsx
+++ b/src/component/button/PrintButton/PrintButton.tsx
@@ -7,6 +7,8 @@ import PrintPanelV3, { PrintConfig } from '../../PrintPanel/PrintPanelV3';
 import { TooltipPlacement } from 'antd/lib/tooltip';
 import { ButtonProps } from 'antd/lib/button';
 
+import DeviceDetector from '../../../util/DeviceDetector';
+
 interface DefaultPrintButtonProps {
   type: 'default' | 'primary' | 'ghost' | 'dashed' | 'danger' | 'link';
   shape: 'circle' | 'round';
@@ -77,6 +79,8 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
       winVisible
     } = this.state;
 
+    const isMobile = DeviceDetector.isMobileDevice();
+
     if (!config) {
       return <div />;
     }
@@ -95,9 +99,9 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
         <Window
           onEscape={this.changeFullPrintWindowVisibility}
           title={t('PrintPanel.windowTitle')}
-          width={750}
+          width={isMobile ? 'auto' : 750}
           y={50}
-          x={100}
+          x={isMobile ? 0 : 100}
           enableResizing={false}
           collapseTooltip={t('General.collapse')}
           bounds="#app"

--- a/src/component/button/PrintButton/PrintButton.tsx
+++ b/src/component/button/PrintButton/PrintButton.tsx
@@ -7,8 +7,6 @@ import PrintPanelV3, { PrintConfig } from '../../PrintPanel/PrintPanelV3';
 import { TooltipPlacement } from 'antd/lib/tooltip';
 import { ButtonProps } from 'antd/lib/button';
 
-import DeviceDetector from '../../../util/DeviceDetector';
-
 interface DefaultPrintButtonProps {
   type: 'default' | 'primary' | 'ghost' | 'dashed' | 'danger' | 'link';
   shape: 'circle' | 'round';
@@ -79,8 +77,6 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
       winVisible
     } = this.state;
 
-    const isMobile = DeviceDetector.isMobileDevice();
-
     if (!config) {
       return <div />;
     }
@@ -99,9 +95,9 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
         <Window
           onEscape={this.changeFullPrintWindowVisibility}
           title={t('PrintPanel.windowTitle')}
-          width={isMobile ? 'auto' : 750}
+          width={750}
           y={50}
-          x={isMobile ? 0 : 100}
+          x={100}
           enableResizing={false}
           collapseTooltip={t('General.collapse')}
           bounds="#app"


### PR DESCRIPTION
This uses custom css for mobile devices
- hiding the preview window and button
- initially uses auto size for panel width
- make use of `flex` in grid layout

![Peek 2021-01-28 10-17](https://user-images.githubusercontent.com/37144910/106116754-929e6a00-6152-11eb-83e3-1bc81a34373f.gif)



@terrestris/devs please note.