### PR TITLE
Fix panel min-width in mobile mode

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -40,5 +40,6 @@ button, .ant-collapse-header, .react-geo-titlebar {
   .react-geo-panel {
       width: 100% !important;
       transform: translate(0, 100px) !important;
+      min-width: unset !important;
   }
 }


### PR DESCRIPTION
Unset `min-width` for mobile mode.  Needed to display whole panel in mobile mode.

Please note @terrestris/devs 