### PR TITLE
Fix app mode detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "start:boot": "webpack-dev-server --config config/webpack.shogun-boot.config.js --hot",
     "build:static": "node scripts/build.js",
     "build:shogun2": "node scripts/build.js",
+    "build:boot": "node scripts/build.js",
     "test": "node scripts/test.js --config config/jest/jest.config.js --runInBand --no-colors",
     "lint": "eslint -c .eslintrc.js --ext .ts,tsx src/ && tsc --noEmit --project tsconfig.json",
     "lint:fix": "eslint -c .eslintrc.js --ext .ts,tsx src/ --fix",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -6,8 +6,8 @@ const shogun2Path = basePath + 'rest/projectapps/';
 const shogunBootPath = basePath + 'applications/';
 let staticPath = basePath + 'resources/appContext.json';
 let localePath =  basePath + 'resources/i18n/{{lng}}.json';
-const appMode = typeof(APP_MODE) != "undefined" ? APP_MODE : undefined;
-const nodeEnv = typeof(process.env.NODE_ENV) != "undefined" ? process.env.NODE_ENV : undefined;
+const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : '';
+const nodeEnv = typeof(process.env.NODE_ENV) != 'undefined' ? process.env.NODE_ENV : undefined;
 
 if (nodeEnv && nodeEnv.indexOf('production') > -1) {
   localePath = buildPath + 'resources/i18n/{{lng}}.json';

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -15,14 +15,14 @@ if (nodeEnv && nodeEnv.indexOf('production') > -1) {
 
 let appContextPath;
 let layerPath;
-if (appMode === 'start:shogun2') {
+if (appMode.indexOf('shogun2') > -1) {
   appContextPath = shogun2Path;
   layerPath = basePath + 'rest/layers';
 }
-if (appMode === 'start:static') {
+if (appMode.indexOf('static') > -1) {
   appContextPath = staticPath;
 }
-if (appMode === 'start:boot') {
+if (appMode.indexOf('boot') > -1) {
   appContextPath = shogunBootPath;
   layerPath = basePath + 'layers';
 }

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -41,7 +41,7 @@ import BaseAppContextUtil, { AppContextUtil } from './BaseAppContextUtil';
 class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil {
 
   canReadCurrentAppContext() {
-    const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : undefined;
+    const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : '';
 
     return appMode.indexOf('shogun2') > -1 || appMode.indexOf('static') > -1;
   }

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -43,7 +43,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
   canReadCurrentAppContext() {
     const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : undefined;
 
-    return appMode === 'start:shogun2' || appMode === 'start:static';
+    return appMode.indexOf('shogun2') > -1 || appMode.indexOf('static') > -1;
   }
 
   /**

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -41,7 +41,7 @@ const layerService = new LayerService();
 class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextUtil {
 
   canReadCurrentAppContext() {
-    const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : undefined;
+    const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : '';
 
     return appMode.indexOf('boot') > -1;
   }

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -43,7 +43,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
   canReadCurrentAppContext() {
     const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : undefined;
 
-    return appMode === 'start:boot';
+    return appMode.indexOf('boot') > -1;
   }
 
   /**


### PR DESCRIPTION
The `APP_MODE` may contain either `start:[MODE]` or `build:[MODE]` (e.g. `start:boot` or `build:boot`) depending on the current build context. This fix adds support for both of them.

It also includes the `build:boot` script as this is required to detect the correct mode while handling a build version for shogun-boot.