### PR TITLE
Add layer-buttons for classic layer tree

### DIFF
--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.css
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.css
@@ -28,6 +28,7 @@
 
 .layer-tree-classic .react-geo-layertree .ant-tree-node-content-wrapper {
   background-color: unset;
+  width: 100%;
 }
 
 .layer-transparency {
@@ -53,10 +54,6 @@
   position: absolute;
   right: 5px;
   top: 52px;
-}
-
-.layer-tree-classic .ant-tree-node-content-wrapper {
-  width: 100%;
 }
 
 .classic-tree-node-header {

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.css
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.css
@@ -55,6 +55,23 @@
   top: 52px;
 }
 
+.layer-tree-classic .ant-tree-node-content-wrapper {
+  width: 100%;
+}
+
+.classic-tree-node-header {
+  display: flex;
+}
+
+.classic-tree-node-header-buttons {
+  margin-left: auto;
+  display: flex;
+}
+
+.classic-tree-node-header-buttons div {
+    margin-left: 5px;
+}
+
 @media only screen and (min-width: 768px) {
   .layer-tree-classic-close-button {
     display: none;

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -19,7 +19,8 @@ import { hideLayerTree } from '../../../state/actions/AppStateAction';
 interface DefaultLayerTreeClassicProps {
   extraLegendParams: {};
   dispatch: (arg: any) => void;
-  showLayerButtons: boolean;
+  showContextMenu: boolean;
+  showApplyTimeInterval: boolean;
 }
 
 interface LayerTreeClassicProps extends Partial<DefaultLayerTreeClassicProps> {
@@ -41,7 +42,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       'LEGEND_OPTIONS': 'fontAntiAliasing:true;forceLabels:on;fontName:DejaVu Sans Condensed'
     },
     dispatch: () => {},
-    showLayerButtons: true
+    showContextMenu: true,
+    showApplyTimeInterval: true
   };
 
   /**
@@ -63,7 +65,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       map,
       extraLegendParams,
       t,
-      showLayerButtons
+      showContextMenu,
+      showApplyTimeInterval
     } = this.props;
 
     const unit = map.getView().getProjection().getUnits();
@@ -82,23 +85,21 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
             <div>
               {layer.get('name')}
             </div>
-            {showLayerButtons &&
-              <div className='classic-tree-node-header-buttons'>
-                {(layer.get('type') === 'WMSTime') &&
-                    <LayerTreeApplyTimeInterval
-                      map={this.props.map}
-                      layer={layer}
-                      t={t}
-                    />
-                }
-                {(layer instanceof OlLayer) &&
-                  <LayerTreeDropdownContextMenu
-                    map={this.props.map}
-                    layer={layer}
-                    t={t} />
-                }
-              </div>
-            }
+            <div className='classic-tree-node-header-buttons'>
+              {(showContextMenu && layer instanceof OlLayer) &&
+                <LayerTreeDropdownContextMenu
+                  map={this.props.map}
+                  layer={layer}
+                  t={t} />
+              }
+              {(showApplyTimeInterval && layer.get('type') === 'WMSTime') &&
+                <LayerTreeApplyTimeInterval
+                  map={this.props.map}
+                  layer={layer}
+                  t={t}
+                />
+              }
+            </div>
           </div>
           {layer.get('visible') &&
             <>

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 
 import OlLayerGroup from 'ol/layer/Group';
+import OlLayer from 'ol/layer/Layer';
 
 import LayerTree from '@terrestris/react-geo/dist/LayerTree/LayerTree';
 import Legend from '@terrestris/react-geo/dist/Legend/Legend';
 import LayerTransparencySlider from '@terrestris/react-geo/dist/Slider/LayerTransparencySlider/LayerTransparencySlider';
 import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import LayerTreeApplyTimeInterval from '../../container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval';
+import LayerTreeDropdownContextMenu from '../../container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu';
 
 import {MapUtil} from '@terrestris/ol-util';
 
@@ -72,7 +75,26 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
     } else {
       return (
         <div>
-          {layer.get('name')}
+          <div className="classic-tree-node-header">
+            <div>
+              {layer.get('name')}
+            </div>
+            <div className='classic-tree-node-header-buttons'>
+              {(layer.get('type') === 'WMSTime') &&
+                  <LayerTreeApplyTimeInterval
+                    map={this.props.map}
+                    layer={layer}
+                    t={t}
+                  />
+              }
+              {(layer instanceof OlLayer) &&
+                <LayerTreeDropdownContextMenu
+                  map={this.props.map}
+                  layer={layer}
+                  t={t} />
+              }
+            </div>
+          </div>
           {layer.get('visible') &&
             <>
               <div className='layer-transparency'>

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -19,6 +19,7 @@ import { hideLayerTree } from '../../../state/actions/AppStateAction';
 interface DefaultLayerTreeClassicProps {
   extraLegendParams: {};
   dispatch: (arg: any) => void;
+  showLayerButtons: boolean;
 }
 
 interface LayerTreeClassicProps extends Partial<DefaultLayerTreeClassicProps> {
@@ -39,7 +40,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
     extraLegendParams: {
       'LEGEND_OPTIONS': 'fontAntiAliasing:true;forceLabels:on;fontName:DejaVu Sans Condensed'
     },
-    dispatch: () => {}
+    dispatch: () => {},
+    showLayerButtons: true
   };
 
   /**
@@ -60,7 +62,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
     const {
       map,
       extraLegendParams,
-      t
+      t,
+      showLayerButtons
     } = this.props;
 
     const unit = map.getView().getProjection().getUnits();
@@ -79,21 +82,23 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
             <div>
               {layer.get('name')}
             </div>
-            <div className='classic-tree-node-header-buttons'>
-              {(layer.get('type') === 'WMSTime') &&
-                  <LayerTreeApplyTimeInterval
+            {showLayerButtons &&
+              <div className='classic-tree-node-header-buttons'>
+                {(layer.get('type') === 'WMSTime') &&
+                    <LayerTreeApplyTimeInterval
+                      map={this.props.map}
+                      layer={layer}
+                      t={t}
+                    />
+                }
+                {(layer instanceof OlLayer) &&
+                  <LayerTreeDropdownContextMenu
                     map={this.props.map}
                     layer={layer}
-                    t={t}
-                  />
-              }
-              {(layer instanceof OlLayer) &&
-                <LayerTreeDropdownContextMenu
-                  map={this.props.map}
-                  layer={layer}
-                  t={t} />
-              }
-            </div>
+                    t={t} />
+                }
+              </div>
+            }
           </div>
           {layer.get('visible') &&
             <>


### PR DESCRIPTION
## Feature
- Add settings dropdown button ( `LayerTreeDropDownContextMenu`)
- For layers of type `WMSTime`, add calendar button to adjust time interval (`LayerTreeApplyTimeInterval`)

![image](https://user-images.githubusercontent.com/37144910/108861150-34e52c80-75ef-11eb-9c43-fdff7dfe90f2.png)

What do you think @terrestris/devs ?