### PR TITLE
Gray out layers that aren't in given scale range

### DIFF
--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.css
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.css
@@ -16,8 +16,12 @@
   font-size: 14px;
 }
 
-.layer-tree-classic .ant-tree-title .react-geo-legend>img {
-    max-width: 90%;
+.layer-tree-classic .ant-tree-title .react-geo-legend > img {
+  max-width: 90%;
+}
+
+.layer-tree-classic .ant-tree-title span.layer-not-visible {
+  color: gray !important;
 }
 
 @media only screen and (max-width: 768px) {
@@ -32,13 +36,13 @@
 }
 
 .layer-transparency {
-    display: flex;
-    padding-top: 10px;
+  display: flex;
+  padding-top: 10px;
 }
 .layer-transparency .ant-slider {
-    bottom: 5px;
-    left: 5px;
-    width: 100px;
+  bottom: 5px;
+  left: 5px;
+  width: 100px;
 }
 
 .layer-transparency .ant-slider .ant-slider-step {

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -79,12 +79,18 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
         </div>
       );
     } else {
+      const isInResolutionRange = MapUtil.layerInResolutionRange(layer, map);
+
       return (
         <div>
           <div className="classic-tree-node-header">
-            <div>
-              {layer.get('name')}
-            </div>
+            <span
+              className={isInResolutionRange ? undefined : 'layer-not-visible'}
+            >
+              {
+                layer.get('name')
+              }
+            </span>
             <div className='classic-tree-node-header-buttons'>
               {(showContextMenu && layer instanceof OlLayer) &&
                 <LayerTreeDropdownContextMenu
@@ -101,7 +107,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
               }
             </div>
           </div>
-          {layer.get('visible') &&
+          {(layer.get('visible') && isInResolutionRange) &&
             <>
               <div className='layer-transparency'>
                 {t('LayerTreeClassic.transparency')}


### PR DESCRIPTION
This grays out layer entries in the `LayerTreeClassic` which are outside the configured scale range.

Please review @terrestris/devs.