### PR TITLE
Add aliases to webpack conf

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -162,6 +162,7 @@ const commonWebpackConfig = {
     alias: {
       // This is need if working with npm link or while invoking react-geo-baseclient as submodule
       // in some other project
+      'react-geo-baseclient': path.join(__dirname + '/../', 'src'),
       '@terrestris/base-util': path.join(__dirname + '/../', 'node_modules', '@terrestris/base-util'),
       '@terrestris/ol-util': path.join(__dirname + '/../', 'node_modules', '@terrestris/ol-util'),
       '@terrestris/react-geo': path.join(__dirname + '/../', 'node_modules', '@terrestris/react-geo'),

--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -169,6 +169,8 @@ const commonWebpackConfig = {
       'react': path.join(__dirname + '/../', 'node_modules', 'react'),
       'react-redux': path.join(__dirname + '/../', 'node_modules', 'react-redux'),
       'react-i18next': path.join(__dirname + '/../', 'node_modules', 'react-i18next'),
+      '@ant-design/icons': path.join(__dirname + '/../', 'node_modules', '@ant-design/icons'),
+      'moment': path.join(__dirname + '/../', 'node_modules', 'moment'),
       'ol': path.join(__dirname + '/../', 'node_modules', 'ol')
     }
   }


### PR DESCRIPTION
This adds two depency aliases for `@ant-design/icons` and `moment`. 

In addition an alias for `react-geo-baseclient` is added which allows projects easier modules import statements, for example:

```js
import ApplicationService from '../../../../react-geo-baseclient/src/service/ApplicationService/ApplicationService';
```

⇩

```js
import ApplicationService from 'react-geo-baseclient/service/ApplicationService/ApplicationService';
```

Please review @terrestris/devs.