### PR TITLE
Update webpack proxy conf for shogun-boot backends

### DIFF
--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -120,6 +120,7 @@ const delayedConf =
       const proxyCommonConf = {
         logLevel: 'info',
         secure: false,
+        followRedirects: true,
         target: 'https://localhost/',
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -118,6 +118,7 @@ const delayedConf =
       ];
 
       const proxyCommonConf = {
+        logLevel: 'info',
         secure: false,
         target: 'https://localhost/',
         headers: {

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -100,7 +100,6 @@ const delayedConf =
             // csrfHeader: csrfHeader,
             // csrfParameterName: csrfParameterName,
             // csrfToken: csrfToken,
-            // Authorization: `Bearer ${accessToken}`
           },
           hash: true,
           minify: {
@@ -122,7 +121,6 @@ const delayedConf =
         secure: false,
         target: 'https://localhost/',
         headers: {
-          'Access-Control-Allow-Origin': '*',
           Authorization: `Bearer ${accessToken}`,
           Cookie: `token=${accessToken}`
         }

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -159,7 +159,8 @@ const delayedConf =
             '/files',
             '/imagefiles',
             '/users',
-            '/info/app'
+            '/info/app',
+            '/geoserver'
           ]
         }],
         publicPath: 'https://localhost:9090/'


### PR DESCRIPTION
This updates the webpack proxy middleware conf by:

* Removing an invalid request header.
* Specifying the `info` loglevel (= default).
* Following redirects.
* Adding path `/geoserver`.

Please review @terrestris/devs.