### PR TITLE
Use other text color for hyperlinks

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -11,7 +11,7 @@ body {
  * Make most of the text elements use the defined text color.
  * This list may be incomplete
  */
-p, b, h1, h2, h3, h4, h5, em, span:not(.fa), div:not(class^="ant-tooltip"), a, li {
+p, b, h1, h2, h3, h4, h5, em, span:not(.fa), div:not(class^="ant-tooltip"), a:not(.link), li {
   color: var(--textColor) !important;
 }
 

--- a/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
+++ b/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
@@ -173,7 +173,7 @@ export class FeatureInfoGrid extends React.Component<FeatureInfoGridProps, Featu
   getColumnText(text: any): string | React.ReactElement {
     const colText = text.value;
     if (colText && colText.toString().toLowerCase().indexOf('http') > -1) {
-      return `<a href=${colText} target='_blank'>Link</a>`;
+      return `<a class="link" href=${colText} target='_blank'>Link</a>`;
     }
     return colText;
   }


### PR DESCRIPTION
Use `baseColor` while rendering hyperlink value inside of info feature grid.

Please review @terrestris/devs 