### PR TITLE
Fix encoding in bundle

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const SimpleProgressWebpackPlugin = require('simple-progress-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const HtmlWebpackScriptsPlugin = require('html-webpack-scripts-plugin');
 
 const TARGET = process.env.npm_lifecycle_event;
 const PROJECT_MAIN_PATH = process.env.PROJECT_MAIN_PATH || './';
@@ -154,6 +155,9 @@ const commonWebpackConfig = {
     new SimpleProgressWebpackPlugin({
       format: 'compact'
     }),
+    new HtmlWebpackScriptsPlugin({
+      'charset=utf-8': /bundle/
+    })
   ],
 
   resolve: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "fork-ts-checker-webpack-plugin": "^5.2.0",
         "fs-extra": "^9.0.1",
         "html-webpack-plugin": "^4.4.1",
+        "html-webpack-scripts-plugin": "^1.0.3",
         "http-server": "^0.12.3",
         "jest": "^26.4.2",
         "jest-canvas-mock": "^2.2.0",
@@ -6909,7 +6910,7 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/babel-jest/node_modules/is-number": {
@@ -7050,7 +7051,7 @@
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/babel-jest/node_modules/to-regex-range": {
@@ -12827,6 +12828,15 @@
       "dependencies": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node_modules/html-webpack-scripts-plugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/html-webpack-scripts-plugin/-/html-webpack-scripts-plugin-1.0.3.tgz",
+      "integrity": "sha512-3IhdwHYJUXTGI7a3KkttTk9ZFF5rLMLWTd10BTait8gZBpAEWUNgV4EFBoHJsadS0Qu+e7scvhU0OIHfic2B4A==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^2.5.3"
       }
     },
     "node_modules/htmlparser2": {
@@ -38602,6 +38612,15 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
+      }
+    },
+    "html-webpack-scripts-plugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/html-webpack-scripts-plugin/-/html-webpack-scripts-plugin-1.0.3.tgz",
+      "integrity": "sha512-3IhdwHYJUXTGI7a3KkttTk9ZFF5rLMLWTd10BTait8gZBpAEWUNgV4EFBoHJsadS0Qu+e7scvhU0OIHfic2B4A==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.3"
       }
     },
     "htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "fork-ts-checker-webpack-plugin": "^5.2.0",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "^4.4.1",
+    "html-webpack-scripts-plugin": "^1.0.3",
     "http-server": "^0.12.3",
     "jest": "^26.4.2",
     "jest-canvas-mock": "^2.2.0",


### PR DESCRIPTION
Running in prod mode, you can observe some encoding problems while operating on clients with map projection set to `EPSG:4326`- in mouse position control an `Â` character  is shown up next to degree sign:

![image](https://user-images.githubusercontent.com/3939355/112968749-e0345480-914c-11eb-8b61-4e8ea11fdeef.png)

This PR adds and configures [html-webpack-scripts-plugin](https://www.npmjs.com/package/html-webpack-scripts-plugin) to ensure, that `bundle.js` will always be properly encoded as UTF-8 by setting of `charset` attribute into the appropriate script tag:

`<script charset="utf-8" src="bundle.js?d031e7ef9377591e42ad"></script>`

Please review @terrestris/devs 
