### PR TITLE
Layer context menu enhancements

### DIFF
--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
@@ -7,7 +7,6 @@ import Metadata from '../../Modal/Metadata/Metadata';
 import {
   Menu,
   Dropdown,
-  Tooltip,
   Modal
 } from 'antd';
 const MenuItem = Menu.Item;
@@ -165,15 +164,9 @@ export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropd
           visible={!menuHidden}
           trigger={['click']}
         >
-          <Tooltip
-            title={this.props.t('LayerTreeDropdownContextMenu.layerSettingsTooltipText')}
-            placement="right"
-            mouseEnterDelay={0.5}
-          >
-            <span
-              className="fa fa-cog layer-tree-node-title-settings"
-            />
-          </Tooltip>
+          <span
+            className="fa fa-cog layer-tree-node-title-settings"
+          />
         </Dropdown>
         {metaDataModalVisible ?
           <Metadata

--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
@@ -12,7 +12,7 @@ import {
 } from 'antd';
 const MenuItem = Menu.Item;
 
-const isEmpty = require('lodash/isEmpty');
+import _isEmpty from 'lodash/isEmpty';
 
 interface LayerTreeDropdownContextMenuProps {
   layer: OlLayerBase;
@@ -108,7 +108,7 @@ export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropd
   /**
    * The render function.
    */
-  render () {
+  render() {
     const {
       t,
       layer
@@ -120,23 +120,30 @@ export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropd
       metaDataModalVisible
     } = this.state;
 
+    const showDesciption = !_isEmpty(layer.get('description'));
+    const showMetadata = !_isEmpty(layer.get('metadataIdentifier')) && layer.get('showMetadataInClient');
+
     const settingsMenu = (
       <Menu
         selectable={false}
         onClick={this.onContextMenuItemClick}
       >
-        <MenuItem
-          disabled={isEmpty(layer.get('description'))}
-          key="info"
-        >
-          {t('LayerTreeDropdownContextMenu.layerInfoText')}
-        </MenuItem>
-        <MenuItem
-          disabled={isEmpty(layer.get('metadataIdentifier'))}
-          key="metadata"
-        >
-          {t('LayerTreeDropdownContextMenu.layerMetadataText')}
-        </MenuItem>
+        {
+          showDesciption &&
+          <MenuItem
+            key="info"
+          >
+            {t('LayerTreeDropdownContextMenu.layerInfoText')}
+          </MenuItem>
+        }
+        {
+          showMetadata &&
+          <MenuItem
+            key="metadata"
+          >
+            {t('LayerTreeDropdownContextMenu.layerMetadataText')}
+          </MenuItem>
+        }
       </Menu>
     );
 

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -212,6 +212,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
       tileLayer.set('timeFormat', layer.source.timeFormat);
       tileLayer.set('description', layer.description);
       tileLayer.set('metadataIdentifier', layer.metadataIdentifier);
+      tileLayer.set('showMetadataInClient', layer.showMetadataInClient);
       tileLayer.set('displayColumns', layer.displayColumns);
       tileLayer.set('columnAliasesDe', layer.columnAliasesDe);
       tileLayer.set('columnAliasesEn', layer.columnAliasesEn);
@@ -359,6 +360,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
     }
     tileLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
     tileLayer.set('metadataIdentifier', layerObj.metadataIdentifier);
+    tileLayer.set('showMetadataInClient', layerObj.showMetadataInClient);
     return tileLayer;
   }
 
@@ -439,6 +441,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
     imageLayer.set('convertFeatureInfoValue', layerObj.convertFeatureInfoValue || false);
     imageLayer.set('description', layerObj.description);
     imageLayer.set('metadataIdentifier', layerObj.metadataIdentifier);
+    imageLayer.set('showMetadataInClient', layerObj.showMetadataInClient);
     imageLayer.set('displayColumns', layerObj.displayColumns);
     imageLayer.set('columnAliasesDe', layerObj.columnAliasesDe);
     imageLayer.set('columnAliasesEn', layerObj.columnAliasesEn);


### PR DESCRIPTION
* make `showContextMenu` property optional
* try to estimate whether the context menu should be shown or not depending on given layer record instead
* show only menu entries which has meaningful content (description) or explicitly configured to be visible (metadata)

Please review @terrestris/devs 