### PR TITLE
Webpack config updates

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -166,6 +166,7 @@ const commonWebpackConfig = {
       '@terrestris/base-util': path.join(__dirname + '/../', 'node_modules', '@terrestris/base-util'),
       '@terrestris/ol-util': path.join(__dirname + '/../', 'node_modules', '@terrestris/ol-util'),
       '@terrestris/react-geo': path.join(__dirname + '/../', 'node_modules', '@terrestris/react-geo'),
+      '@terrestris/mapfish-print-manager': path.join(__dirname + '/../', 'node_modules', '@terrestris/mapfish-print-manager'),
       'antd': path.join(__dirname + '/../', 'node_modules', 'antd'),
       'react': path.join(__dirname + '/../', 'node_modules', 'react'),
       'react-redux': path.join(__dirname + '/../', 'node_modules', 'react-redux'),

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -149,7 +149,8 @@ const delayedConf =
             '/files/**',
             '/imagefiles/**',
             '/users/**',
-            '/sso/**'
+            '/sso/**',
+            '/print/**'
           ]
         }, {
           ...proxyCommonConf,
@@ -160,7 +161,8 @@ const delayedConf =
             '/imagefiles',
             '/users',
             '/info/app',
-            '/geoserver'
+            '/geoserver',
+            '/print'
           ]
         }],
         publicPath: 'https://localhost:9091/'


### PR DESCRIPTION
This updates the webpack config by:

* Adding the `print` endpoint(s) to the proxy.
* Adding an alias for the `mapfish-print-manager` package.

Please review @terrestris/devs.