### PR TITLE
Make csrf values/placeholders configurable

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -12,12 +12,11 @@ const PROJECT_MAIN_CLASS = process.env.PROJECT_MAIN_CLASS || 'ProjectMain';
 const RESOURCES_PATH = process.env.RESOURCES_PATH || './src/resources/';
 const APP_PREFIX = process.env.APP_PREFIX;
 
-let CustomCssTheme;
-
+let customCssTheme;
 if (process.env.PROJECT_MAIN_PATH)  {
-  CustomCssTheme = require(PROJECT_MAIN_PATH + 'theme/antLessModifyVars');
+  customCssTheme = require(PROJECT_MAIN_PATH + 'theme/antLessModifyVars');
 } else {
-  CustomCssTheme = path.resolve(PROJECT_MAIN_PATH + 'src/theme/antLessModifyVars');
+  customCssTheme = path.resolve(PROJECT_MAIN_PATH + 'src/theme/antLessModifyVars');
 }
 
 const Logger = winston.createLogger({
@@ -90,7 +89,7 @@ const commonWebpackConfig = {
           loader: 'less-loader',
           options: {
             lessOptions: {
-              modifyVars: CustomCssTheme,
+              modifyVars: customCssTheme,
               javascriptEnabled: true
             }
           }

--- a/config/webpack.production.config.js
+++ b/config/webpack.production.config.js
@@ -5,11 +5,17 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 
 let commonWebpackConfig = commonConfig.commonWebpackConfig;
 const Logger = commonConfig.logger;
+
 let customAppConfig;
 try {
   customAppConfig = require('../../' + process.env.CUSTOM_WEBPACK_CONFIG);
 } catch (error) {
-  Logger.info("No custom app config provided, using defaults.");
+  Logger.info('No custom app config provided, using defaults.');
+}
+
+let customCsrfValues;
+if (customAppConfig && customAppConfig.csrf) {
+  customCsrfValues = customAppConfig.csrf;
 }
 
 // prepare the InterpolateHtmlPlugin
@@ -33,11 +39,11 @@ commonWebpackConfig.plugins = [
     favicon: './public/favicon.ico',
     template: './public/index.html',
     loadingMaskImg: loadingMaskImg,
-    files: {
-      css: [],
+    csrf: {
       csrfToken: '${_csrf.token}',
       csrfHeader: '${_csrf.headerName}',
-      csrfParameterName: '${_csrf.parameterName}'
+      csrfParameterName: '${_csrf.parameterName}',
+      ...customCsrfValues
     },
     hash: true,
     minify: {

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -10,11 +10,17 @@ const cheerio = require('cheerio');
 const commonConfig = require('./webpack.common.config.js');
 let commonWebpackConfig = commonConfig.commonWebpackConfig;
 const Logger = commonConfig.logger;
+
 let customAppConfig;
 try {
   customAppConfig = require('../../' + process.env.CUSTOM_WEBPACK_CONFIG);
 } catch (error) {
-  Logger.info("No custom app config provided, using defaults.");
+  Logger.info('No custom app config provided, using defaults.');
+}
+
+let customCsrfValues;
+if (customAppConfig && customAppConfig.csrf) {
+  customCsrfValues = customAppConfig.csrf;
 }
 
 commonWebpackConfig.mode = 'development';
@@ -95,11 +101,12 @@ const delayedConf =
         new HtmlWebpackPlugin({
           filename: 'index.html',
           favicon: './public/favicon.ico',
-          headers: {
-            // TODO: enable CSRF
+          csrf: {
+            // TODO Fix reading CSRF values
             // csrfHeader: csrfHeader,
             // csrfParameterName: csrfParameterName,
             // csrfToken: csrfToken,
+            ...customCsrfValues
           },
           hash: true,
           minify: {

--- a/config/webpack.shogun2.config.js
+++ b/config/webpack.shogun2.config.js
@@ -10,11 +10,17 @@ const cheerio = require('cheerio');
 const commonConfig = require('./webpack.common.config.js');
 let commonWebpackConfig = commonConfig.commonWebpackConfig;
 const Logger = commonConfig.logger;
+
 let customAppConfig;
 try {
   customAppConfig = require('../../' + process.env.CUSTOM_WEBPACK_CONFIG);
 } catch (error) {
-  Logger.info("No custom app config provided, using defaults.");
+  Logger.info('No custom app config provided, using defaults.');
+}
+
+let customCsrfValues;
+if (customAppConfig && customAppConfig.csrf) {
+  customCsrfValues = customAppConfig.csrf;
 }
 
 commonWebpackConfig.mode = 'development';
@@ -29,17 +35,17 @@ const userName = process.env.SHOGUN_USER;
 const password = process.env.SHOGUN_PASS;
 
 if (!backendUrl) {
-  Logger.error(`No SHOGun base URL set in .shogunrc.`);
+  Logger.error('No SHOGun base URL set in .shogunrc.');
   return;
 }
 
 if (!userName) {
-  Logger.error(`No SHOGun user set in .shogunrc.`);
+  Logger.error('No SHOGun user set in .shogunrc.');
   return;
 }
 
 if (!password) {
-  Logger.error(`No SHOGun password set in .shogunrc.`);
+  Logger.error('No SHOGun password set in .shogunrc.');
   return;
 }
 
@@ -126,10 +132,11 @@ const delayedConf =
                 new HtmlWebpackPlugin({
                   favicon: './public/icon_terrestris.png',
                   filename: 'index.html',
-                  files: {
+                  csrf: {
                     csrfHeader: csrfHeader,
                     csrfParameterName: csrfParameterName,
-                    csrfToken: csrfToken
+                    csrfToken: csrfToken,
+                    ...customCsrfValues
                   },
                   hash: true,
                   minify: {

--- a/config/webpack.static.config.js
+++ b/config/webpack.static.config.js
@@ -7,11 +7,12 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const commonConfig = require('./webpack.common.config.js');
 let commonWebpackConfig = commonConfig.commonWebpackConfig;
 const Logger = commonConfig.logger;
+
 let customAppConfig;
 try {
   customAppConfig = require('../../' + process.env.CUSTOM_WEBPACK_CONFIG);
 } catch (error) {
-  Logger.info("No custom app config provided, using defaults.");
+  Logger.info('No custom app config provided, using defaults.');
 }
 
 commonWebpackConfig.mode = 'development';

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <% if (htmlWebpackPlugin.options.files && htmlWebpackPlugin.options.files.csrfToken) { %>
-      <meta name="_csrf" content="<%= htmlWebpackPlugin.options.files.csrfToken %>" />
-      <meta name="_csrf_header" content="<%= htmlWebpackPlugin.options.files.csrfHeader %>" />
-      <meta name="_csrf_parameter_name" content="<%= htmlWebpackPlugin.options.files.csrfParameterName %>" />
+    <% if (htmlWebpackPlugin.options.csrf && htmlWebpackPlugin.options.csrf.csrfToken &&
+      htmlWebpackPlugin.options.csrf.csrfHeader && htmlWebpackPlugin.options.csrf.csrfParameterName) { %>
+      <meta name="_csrf" content="<%= htmlWebpackPlugin.options.csrf.csrfToken %>" />
+      <meta name="_csrf_header" content="<%= htmlWebpackPlugin.options.csrf.csrfHeader %>" />
+      <meta name="_csrf_parameter_name" content="<%= htmlWebpackPlugin.options.csrf.csrfParameterName %>" />
       <% } %>
     <!--
       manifest.json provides metadata used when your web app is added to the


### PR DESCRIPTION
This suggests to make the csrf values/placeholdes in the target html configurable. This can be useful to pass custom placeholder names or to simply disable the appropriate meta tags.

Example for unsetting the values and also the tag generation in the custom `webpack.config.js`:

```js
module.exports = {
  appTitle: 'My App',
  loadingMaskImg: './resources/img/my-logo.svg',
  csrf: {
    csrfToken: null,
    csrfHeader: null,
    csrfParameterName: null
  }
};
```

As this will override the given defaults only, this is an opt-in and no project adaptions are needed.

Please review @terrestris/devs.