### PR TITLE
Add layer tree menu entry to zoom to layer's extent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1781,9 +1781,9 @@
       }
     },
     "@terrestris/ol-util": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.0.3.tgz",
-      "integrity": "sha512-FwriYsNNync1x5PHGXPd2iP0ZWDcAHnz7rI5IdnSI7GNXm5sv7l98Ruw5Zesip2eYXE4pQgVPDJ4oQ6VJhnjZA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.0.tgz",
+      "integrity": "sha512-3b6TJJTzetq0yJ4r93O9xDhtot2gvwH541V1pmVFQuJ4Z1lbhOtWaTzrIC0JpOEK2Qt8tDIjzFjoe06itSp/Ng==",
       "requires": {
         "@terrestris/base-util": "^1.0.0",
         "@turf/turf": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@brainhubeu/react-carousel": "^1.19.26",
     "@terrestris/base-util": "^1.0.1",
     "@terrestris/mapfish-print-manager": "^6.3.5",
-    "@terrestris/ol-util": "^4.0.3",
+    "@terrestris/ol-util": "^4.1.0",
     "@terrestris/react-geo": "15.0.0-beta.2",
     "@terrestris/vectortiles": "^0.3.0",
     "antd": "4.8.6",

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -159,7 +159,9 @@
   "LayerTreeDropdownContextMenu": {
     "layerInfoText": "Layerbeschreibung",
     "layerSettingsTooltipText": "Eigenschaften",
-    "layerMetadataText": "Metadaten anzeigen"
+    "layerMetadataText": "Metadaten anzeigen",
+    "layerZoomToExtent": "Auf Layerausdehnung zoomen",
+    "extentError": "Konnte nicht auf die Layerausdehnung zoomen"
   },
   "LayerTreeApplyTimeInterval": {
     "setTimeLineToLayerInterval": "Zeitraum des Layers anwenden"

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -158,7 +158,9 @@
   "LayerTreeDropdownContextMenu": {
     "layerInfoText": "Layer description",
     "layerSettingsTooltipText": "Properties",
-    "layerMetadataText": "Display metadata"
+    "layerMetadataText": "Display metadata",
+    "layerZoomToExtent": "Zoom to layer extent",
+    "extentError": "Could not zoom to the layer extent"
   },
   "LayerTreeApplyTimeInterval": {
     "setTimeLineToLayerInterval": "Apply time interval of the layer"


### PR DESCRIPTION
This adds a new menu entry that fits the extent of the map to the extent defined in the capabilities of the selected layer.

Requires [!412](https://github.com/terrestris/ol-util/pull/412).

Please review @terrestris/devs.