### PR TITLE
Pass map projection to tile layer in shogun-boot app parser.

### DIFF
--- a/src/util/AppContextUtil/BaseAppContextUtil.ts
+++ b/src/util/AppContextUtil/BaseAppContextUtil.ts
@@ -7,7 +7,7 @@ export interface AppContextUtil {
   canReadCurrentAppContext: () => boolean;
   appContextToState: (appContext: any) => {};
   parseLayer: (layer: any, projection?: ProjectionLike) => OlLayerBase | Promise<OlLayerBase>;
-  parseTileLayer: (layer: any) => {};
+  parseTileLayer: (layer: any, projection?: ProjectionLike) => {};
   parseImageLayer: (layer: any) => {};
   getToolsForToolbar: (activeModules: any[], map: any,
     appContext: any,t: (arg: string) => string, config?: any,

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -190,7 +190,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
     }
 
     if (layer.type === 'TILEWMS' || layer.type === 'WMSTime') {
-      olLayer = this.parseTileLayer(layer);
+      olLayer = this.parseTileLayer(layer, projection);
     }
 
     return olLayer;
@@ -198,9 +198,9 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
 
   /**
    * Parse and create a tile layer.
-   * @return {ol.layer.Tile} the new layer
+   * @return {ol.layer.Tile} The new layer
    */
-  parseTileLayer(layer: Layer) {
+  parseTileLayer(layer: Layer, projection?: ProjectionLike) {
     const {
       sourceConfig,
       clientConfig
@@ -218,8 +218,8 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       startDate,
       endDate,
       tileSize = 256,
-      resolutions,
-      extent
+      tileOrigin,
+      resolutions
     } = sourceConfig || {};
 
     const {
@@ -235,11 +235,11 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
     const defaultFormat = timeFormat || 'YYYY-MM-DD';
 
     let tileGrid;
-    if (tileSize && resolutions && extent) {
+    if (tileSize && resolutions && tileOrigin) {
       tileGrid = new OlTileGrid({
         resolutions: resolutions,
         tileSize: [tileSize, tileSize],
-        extent: extent
+        origin: tileOrigin
       });
     }
 
@@ -247,6 +247,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       url: url,
       tileGrid: tileGrid,
       attributions: attribution,
+      projection: projection,
       params: {
         'LAYERS': layerNames,
         'TILED': requestWithTiled,


### PR DESCRIPTION
This suggest to pass the map projection to tile layers and to create the tile grid with the tile origin instead of extent.

Please review @terrestris/devs.