### PR TITLE
showZoomToLayerExtent property

### DIFF
--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -23,6 +23,7 @@ interface DefaultLayerTreeClassicProps {
   extraLegendParams: {};
   dispatch: (arg: any) => void;
   showContextMenu?: boolean;
+  showZoomToLayerExtent?: boolean;
   showApplyTimeInterval: boolean;
 }
 
@@ -48,7 +49,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       TRANSPARENT: true
     },
     dispatch: () => {},
-    showApplyTimeInterval: true
+    showApplyTimeInterval: true,
+    showZoomToLayerExtent: true
   };
 
   /**
@@ -69,15 +71,21 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
    * @param layer Layer entry.
    */
   showContextMenu(layer: OlLayer) {
-    if (_isBoolean(this.props.showContextMenu)) {
-      return this.props.showContextMenu;
+
+    const {
+      showZoomToLayerExtent,
+      showContextMenu
+    } = this.props;
+
+    if (_isBoolean(showContextMenu)) {
+      return showContextMenu;
     }
 
     const showDescription = !_isEmpty(layer.get('description'));
     const showMetadata = !_isEmpty(layer.get('metadataIdentifier')) &&
       layer.get('showMetadataInClient');
 
-    return showDescription || showMetadata;
+    return showDescription || showMetadata || showZoomToLayerExtent;
   }
 
   /**
@@ -90,6 +98,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       map,
       extraLegendParams,
       t,
+      showZoomToLayerExtent,
       showApplyTimeInterval
     } = this.props;
 
@@ -120,6 +129,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
                 <LayerTreeDropdownContextMenu
                   map={this.props.map}
                   layer={layer}
+                  showZoomToLayerExtent={showZoomToLayerExtent}
                   t={t} />
               }
               {(showApplyTimeInterval && layer.get('type') === 'WMSTime') &&

--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import OlLayerBase from 'ol/layer/Base';
+import OlMap from 'ol/Map';
 import { transformExtent } from 'ol/proj';
 
 import {
@@ -20,10 +21,14 @@ import Logger from '@terrestris/base-util/dist/Logger';
 
 import Metadata from '../../Modal/Metadata/Metadata';
 
+interface LayerTreeDropdownContextMenuDefaultProps {
+  showZoomToLayerExtent: boolean;
+}
+
 interface LayerTreeDropdownContextMenuProps {
   layer: OlLayerBase;
   t: (arg: string) => {};
-  map: any;
+  map: OlMap;
 }
 
 interface LayerTreeDropdownContextMenuState {
@@ -33,6 +38,8 @@ interface LayerTreeDropdownContextMenuState {
   isLoadingExtent: boolean;
 }
 
+type ComponentProps = LayerTreeDropdownContextMenuDefaultProps & LayerTreeDropdownContextMenuProps;
+
 /**
  * Class LayerTreeDropdownContextMenu.
  *
@@ -40,14 +47,18 @@ interface LayerTreeDropdownContextMenuState {
  * @extends React.Component
  */
 // eslint-disable-next-line
-export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropdownContextMenuProps, LayerTreeDropdownContextMenuState> {
+export class LayerTreeDropdownContextMenu extends React.Component<ComponentProps, LayerTreeDropdownContextMenuState> {
 
+
+  public static defaultProps: LayerTreeDropdownContextMenuDefaultProps = {
+    showZoomToLayerExtent: true
+  };
   /**
    * Creates the LayerTreeDropdownContextMenu.
    *
    * @constructs LayerTreeDropdownContextMenu
    */
-  constructor(props: LayerTreeDropdownContextMenuProps) {
+  constructor(props: ComponentProps) {
     super(props);
 
     // binds
@@ -151,7 +162,8 @@ export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropd
   render() {
     const {
       t,
-      layer
+      layer,
+      showZoomToLayerExtent
     } = this.props;
 
     const {
@@ -185,6 +197,7 @@ export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropd
           </MenuItem>
         }
         {
+          showZoomToLayerExtent &&
           <MenuItem
             key="zoomToExtent"
           >
@@ -220,12 +233,14 @@ export class LayerTreeDropdownContextMenu extends React.Component<LayerTreeDropd
             className="fa fa-cog layer-tree-node-title-settings"
           />
         </Dropdown>
-        {metaDataModalVisible ?
+        {
+          metaDataModalVisible &&
           <Metadata
             layer={layer}
             t={t}
             onCancel={() => this.changeMetadataModalVisibility()} >
-          </Metadata> : null}
+          </Metadata>
+        }
       </div>
     );
   }


### PR DESCRIPTION
Add optional property to decide whether the zoom to extent context menu entry should be shown (default) or not.

Default is set to `true` so behaviour of other clients should stay unchanged.

Please review @terrestris/devs 
