### PR TITLE
ClassicTree full legend size

### DIFF
--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -44,8 +44,6 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
   public static defaultProps: DefaultLayerTreeClassicProps = {
     extraLegendParams: {
       LEGEND_OPTIONS: 'fontAntiAliasing:true;forceLabels:on;fontName:DejaVu Sans Condensed',
-      WIDTH: 30 * 1.5,
-      HEIGHT: 30,
       TRANSPARENT: true
     },
     dispatch: () => {},


### PR DESCRIPTION
### Problem
Malformed and unreadable legends
### Fix
Unset legend image size params.  Request full size legend.  

The final size is set via CSS in the component (`max-width: 90%;` in `LayerTreeClassic.css`).  Not sure about this, there might be a reason for the values I deleted, please review
@dnlkoch @weskamm @annarieger 

![image](https://user-images.githubusercontent.com/37144910/114842714-67cec400-9dd9-11eb-8da8-094ab78ce71e.png)
