### PR TITLE
Makes feature info window height configurable

### DIFF
--- a/src/component/Menu/FeatureInfo/FeatureInfo.tsx
+++ b/src/component/Menu/FeatureInfo/FeatureInfo.tsx
@@ -59,6 +59,11 @@ interface FeatureInfoProps extends Partial<DefaultFeatureInfoProps> {
    * The window position.
    */
   windowPosition?: [number, number];
+
+  /**
+   * The window height.
+   */
+   windowHeight?: number;
 }
 
 interface FeatureInfoState {
@@ -346,6 +351,7 @@ export class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoSt
       t,
       dispatch,
       windowPosition,
+      windowHeight,
       ...passThroughProps
     } = this.props;
 
@@ -397,7 +403,7 @@ export class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoSt
               title={winTitle}
               minWidth={500}
               maxWidth={1000}
-              height={300}
+              height={windowHeight > 0 ? windowHeight : 300}
               maxHeight={1000}
               x={windowPosition && windowPosition[0] || 50}
               y={windowPosition && windowPosition[1] || 50}


### PR DESCRIPTION
This MR

- makes feature info window height configurable and uses a default value (`300`) as fallback, if height isn't provided or set to `0`

@terrestris/devs please review