### PR TITLE
Fix constrainResolution for new Views

### DIFF
--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -171,7 +171,9 @@ export class Footer extends React.Component<FooterProps, FooterState> {
       .reverse();
     const newView = new OlView({
       projection: newProj,
-      resolutions: resolutions
+      resolutions: resolutions,
+      constrainOnlyCenter: true,
+      constrainResolution: true
     });
     map.setView(newView);
     newView.fit(transformedExtent);

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -514,8 +514,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
             iconName="fas fa-expand"
             tooltip={t('ZoomToExtent.tooltip')}
             tooltipPlacement={'right'}
-            constrainResolution={true}
-            constrainOnlyCenter={true}
+            constrainViewResolution={true}
           />);
           return;
         case 'shogun-button-print':

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -514,6 +514,8 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
             iconName="fas fa-expand"
             tooltip={t('ZoomToExtent.tooltip')}
             tooltipPlacement={'right'}
+            constrainResolution={true}
+            constrainOnlyCenter={true}
           />);
           return;
         case 'shogun-button-print':

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -465,6 +465,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
             iconName="fas fa-expand"
             tooltip={t('ZoomToExtent.tooltip')}
             tooltipPlacement={'right'}
+            constrainViewResolution={true}
           />);
           return;
         case 'shogun-button-print':


### PR DESCRIPTION
The default zoom behaviour of a view should not allow intermediate zoom levels and the constraint shall only be applied for center (cf. #776, #736).  

### Bug
View setting falls back to default value which is `false` when **a)** changing projection and **b)** using the `zoom-to-extent` button.  

This PR should fix the issue.  

@terrestris/devs  please review.