### PR TITLE
Enable configuration of project specific reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ PROJECT_MAIN_CLASS=ProjectMain
 # The paths !!! relative to Main Component in react-geo-baseclient/packages/baseclient/src/Main.tsx !!!
 PROJECT_MAIN_PATH='../../myproject/'
 
+# The path to the project main reducer (!!! relative from ProjectMain path)
+# This config is optional. When not configured, the default reducer of baseclient will be used as usual.
+PROJECT_REDUCER_PATH=src/store/myreducers
+
 # resources path relative to webpack config in react-geo-baseclient/packages/baseclient/config
 RESOURCES_PATH='../myproject/resources/'
 

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -1,10 +1,6 @@
 module.exports = {
   verbose: true,
-  rootDir: "../../",
-  globals: {
-    PROJECT_MAIN_PATH: './',
-    PROJECT_MAIN_CLASS: 'ProjectMain'
-  },
+  rootDir: '../../',
   testEnvironment: 'jsdom',
   preset: 'jest-puppeteer',
   moduleFileExtensions: [

--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -9,6 +9,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TARGET = process.env.npm_lifecycle_event;
 const PROJECT_MAIN_PATH = process.env.PROJECT_MAIN_PATH || './';
 const PROJECT_MAIN_CLASS = process.env.PROJECT_MAIN_CLASS || 'ProjectMain';
+const PROJECT_REDUCER_PATH = process.env.PROJECT_REDUCER_PATH;
 const RESOURCES_PATH = process.env.RESOURCES_PATH || './src/resources/';
 const APP_PREFIX = process.env.APP_PREFIX;
 
@@ -170,10 +171,13 @@ const commonWebpackConfig = {
       ]
     }),
     new webpack.DefinePlugin({
-      PROJECT_MAIN_PATH: JSON.stringify(PROJECT_MAIN_PATH),
-      PROJECT_MAIN_CLASS: new RegExp('^./' + PROJECT_MAIN_CLASS + '\\.(jsx|js|ts|tsx)$'),
-      APP_PREFIX: JSON.stringify(APP_PREFIX),
-      ___TEST___: JSON.stringify(TARGET.indexOf('test') > -1)
+      'process.env': {
+        APP_PREFIX: JSON.stringify(APP_PREFIX),
+        PROJECT_MAIN_PATH: JSON.stringify(PROJECT_MAIN_PATH),
+        PROJECT_MAIN_CLASS: new RegExp('^./' + PROJECT_MAIN_CLASS + '\\.(jsx|js|ts|tsx)$'),
+        PROJECT_REDUCER_PATH: PROJECT_REDUCER_PATH ? JSON.stringify(PROJECT_REDUCER_PATH) : false,
+        APP_MODE: JSON.stringify(TARGET)
+      }
     }),
     new SimpleProgressWebpackPlugin({
       format: 'compact'

--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -14,7 +14,7 @@ const RESOURCES_PATH = process.env.RESOURCES_PATH || './src/resources/';
 const APP_PREFIX = process.env.APP_PREFIX;
 
 let customCssTheme;
-if (process.env.PROJECT_MAIN_PATH)  {
+if (process.env.PROJECT_MAIN_PATH) {
   customCssTheme = require(PROJECT_MAIN_PATH + 'theme/antLessModifyVars');
 } else {
   customCssTheme = path.resolve(PROJECT_MAIN_PATH + 'src/theme/antLessModifyVars');
@@ -79,8 +79,8 @@ const commonWebpackConfig = {
         ),
         [
           customAppConfig &&
-          customAppConfig.tsLoaderIncludes &&
-          Array.isArray(customAppConfig.tsLoaderIncludes)
+            customAppConfig.tsLoaderIncludes &&
+            Array.isArray(customAppConfig.tsLoaderIncludes)
             ? customAppConfig.tsLoaderIncludes.map((entry) => {
               return path.resolve(__dirname, entry);
             })
@@ -208,6 +208,5 @@ const commonWebpackConfig = {
 
 module.exports = {
   logger: Logger,
-  commonWebpackConfig: commonWebpackConfig,
-  TARGET: TARGET
+  commonWebpackConfig: commonWebpackConfig
 };

--- a/config/webpack.production.config.js
+++ b/config/webpack.production.config.js
@@ -31,8 +31,7 @@ commonWebpackConfig.plugins = [
   new webpack.DefinePlugin({
     'process.env': {
       NODE_ENV: JSON.stringify('production')
-    },
-    APP_MODE: JSON.stringify(commonConfig.TARGET)
+    }
   }),
   new HtmlWebpackPlugin({
     filename: 'index.html',

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -118,10 +118,7 @@ const delayedConf =
           loadingMaskImg
         }),
         new webpack.ProgressPlugin({ profile: false }),
-        new InterpolateHtmlPlugin(HtmlWebpackPlugin, interpolations),
-        new webpack.DefinePlugin({
-          APP_MODE: JSON.stringify(commonConfig.TARGET)
-        })
+        new InterpolateHtmlPlugin(HtmlWebpackPlugin, interpolations)
       ];
 
       const proxyCommonConf = {

--- a/config/webpack.shogun2.config.js
+++ b/config/webpack.shogun2.config.js
@@ -146,10 +146,7 @@ const delayedConf =
                   template: './public/index.html',
                   loadingMaskImg: loadingMaskImg
                 }),
-                new InterpolateHtmlPlugin(HtmlWebpackPlugin, interpolations),
-                new webpack.DefinePlugin({
-                  APP_MODE: JSON.stringify(commonConfig.TARGET)
-                })
+                new InterpolateHtmlPlugin(HtmlWebpackPlugin, interpolations)
               ];
 
               commonWebpackConfig.devServer = {

--- a/config/webpack.static.config.js
+++ b/config/webpack.static.config.js
@@ -44,10 +44,7 @@ const delayedConf = new Promise(function(resolve) {
       title,
       loadingMaskImg
     }),
-    new InterpolateHtmlPlugin(HtmlWebpackPlugin,interpolations),
-    new webpack.DefinePlugin({
-      APP_MODE: JSON.stringify(commonConfig.TARGET)
-    })
+    new InterpolateHtmlPlugin(HtmlWebpackPlugin,interpolations)
   ];
 
   commonWebpackConfig.devServer = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,4 +7,3 @@ declare module 'react-i18next';
 declare module 'redux-undo';
 declare module 'redux-async-initial-state';
 
-declare var APP_MODE: string;

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   browserContext: 'default',
   server: {
-    command: 'cd build && http-server -p 8000',
-    port: 8000
+    command: 'cd build && http-server -p 8075',
+    port: 8075
   }
-}
+};

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -42,7 +42,7 @@ export class Main extends React.Component<MainProps, MainState> {
     // require.context may not be available in test setup. Use
     // default ProjectMain instead
     // @ts-ignore
-    if (___TEST___){
+    if (process.env.APP_MODE.indexOf('test') > -1) {
       this.main = ProjectMain;
       return;
     }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -49,7 +49,7 @@ export class Main extends React.Component<MainProps, MainState> {
     // load and show the project specific main view, as
     // configured by the user in the projectconfig.js
     // @ts-ignore
-    const context = require.context(PROJECT_MAIN_PATH, true, PROJECT_MAIN_CLASS);
+    const context = require.context(process.env.PROJECT_MAIN_PATH, true, process.env.PROJECT_MAIN_CLASS);
     context.keys().forEach((filename: any) => {
       const main = context(filename);
       this.main = main.default;

--- a/src/ProjectMain.uitest.js
+++ b/src/ProjectMain.uitest.js
@@ -10,7 +10,7 @@ describe('Application render', () => {
       clearInterval(interval);
       resolve();
     }
-  }
+  };
   let getMapPromise = new Promise((resolve, reject) => {
     interval = setInterval(getMapListener, 1000, resolve);
   });
@@ -26,7 +26,7 @@ describe('Application render', () => {
         getMapFound = true;
       }
     });
-    await page.goto('http://0.0.0.0:8000');
+    await page.goto('http://0.0.0.0:8075');
     await page.waitForSelector('#map');
     await page.waitForSelector('canvas');
   }, 120000);

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,6 +1,6 @@
 const nodeEnv = typeof(process.env.NODE_ENV) !== 'undefined' ? process.env.NODE_ENV : undefined;
-const appPrefix = (typeof(APP_PREFIX) !== 'undefined' &&
-  nodeEnv && nodeEnv.indexOf('production') > -1) ? APP_PREFIX : '/';
+const appPrefix = (typeof (process.env.APP_PREFIX) !== 'undefined' &&
+  nodeEnv && nodeEnv.indexOf('production') > -1) ? process.env.APP_PREFIX : '/';
 const basePath = window.location.origin + appPrefix;
 const buildPath = window.location.origin +
   window.location.pathname.match(/^(\/[\w-]*)*\/\/?/)[0];
@@ -8,7 +8,7 @@ const shogun2Path = basePath + 'rest/projectapps/';
 const shogunBootPath = basePath + 'applications/';
 let staticPath = basePath + 'resources/appContext.json';
 let localePath =  basePath + 'resources/i18n/{{lng}}.json';
-const appMode = typeof(APP_MODE) !== 'undefined' ? APP_MODE : '';
+const appMode = typeof (process.env.APP_MODE) !== 'undefined' ? process.env.APP_MODE : '';
 
 if (nodeEnv && nodeEnv.indexOf('production') > -1) {
   localePath = buildPath + 'resources/i18n/{{lng}}.json';

--- a/src/state/reducers/Reducer.ts
+++ b/src/state/reducers/Reducer.ts
@@ -5,15 +5,29 @@ import {
 } from 'redux-async-initial-state';
 import mapView from './MapViewReducer';
 import loadingQueue from './LoadingReducer';
-import appInfo  from './ApplicationInfoReducer';
+import appInfo from './ApplicationInfoReducer';
 import mapLayers from './MapLayersReducer';
-import activeModules  from './ActiveModulesReducer';
-import fetchRemoteFeaturesOfType  from './RemoteFeatureReducer';
+import activeModules from './ActiveModulesReducer';
+import fetchRemoteFeaturesOfType from './RemoteFeatureReducer';
 import dataRange from './DataRangeReducer';
-import appState  from './AppStateReducer';
+import appState from './AppStateReducer';
+import { Logger } from '@terrestris/base-util';
 
-// We need outerReducer to replace full state as soon as it has loaded
-const baseclientMainReducer = outerReducer(combineReducers({
+let projectReducer = {};
+if (process.env.PROJECT_REDUCER_PATH) {
+  try {
+    const context = require('../../' + process.env.PROJECT_MAIN_PATH + process.env.PROJECT_REDUCER_PATH);
+    if (context.default) {
+      projectReducer = context.default;
+    }
+  } catch (error) {
+    Logger.info('Could not load the specified project reducer. ' +
+      'Please check if the path in the .env is set correctly: ', error
+    );
+  }
+}
+
+const baseclientMainReducer = {
   mapView,
   loadingQueue,
   appInfo,
@@ -28,8 +42,14 @@ const baseclientMainReducer = outerReducer(combineReducers({
   dataRange,
   // We need innerReducer to store loading state, i.e. for showing loading spinner
   asyncInitialState: innerReducer
+};
+
+// We need outerReducer to replace full state as soon as it has loaded
+const rootReducer = outerReducer(combineReducers({
+  ...baseclientMainReducer,
+  ...projectReducer
 }));
 
-export type BaseClientState = ReturnType<typeof baseclientMainReducer>;
+export type BaseClientState = ReturnType<typeof rootReducer>;
 
-export default baseclientMainReducer;
+export default rootReducer;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -12,7 +12,7 @@ import { middleware } from 'redux-async-initial-state';
 
 import Logger from '@terrestris/base-util/dist/Logger';
 
-import baseclientMainReducer from './reducers/Reducer';
+import rootReducer from './reducers/Reducer';
 import { getAppContextUtil } from '../util/getAppContextUtil';
 
 import config from '../config/config';
@@ -84,7 +84,7 @@ const loadAppContextStore = async () => {
 };
 
 const store = createStore(
-  baseclientMainReducer,
+  rootReducer,
   composeEnhancers(
     applyMiddleware(middleware(loadAppContextStore)),
     applyMiddleware(thunkMiddleware, loggerMiddleware)

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -45,7 +45,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
   private projection: string;
 
   canReadCurrentAppContext() {
-    const appMode = typeof(APP_MODE) != 'undefined' ? APP_MODE : '';
+    const appMode = typeof (process.env.APP_MODE) != 'undefined' ? process.env.APP_MODE : '';
 
     return appMode.indexOf('shogun2') > -1 || appMode.indexOf('static') > -1;
   }

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -55,7 +55,7 @@ const userService = new UserService();
 class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextUtil {
 
   canReadCurrentAppContext() {
-    const appMode = typeof (APP_MODE) != 'undefined' ? APP_MODE : '';
+    const appMode = typeof (process.env.APP_MODE) != 'undefined' ? process.env.APP_MODE : '';
 
     return appMode.indexOf('boot') > -1;
   }


### PR DESCRIPTION
The baseclient has already support for global state via redux. The whole buisness logic (reducers and actions) is stored under `src/state` and can also be used by projects based on  this client.
Nonetheless, if you need some specific project key, which should be available globally via state, till now you always had to implement the appropriate action and reducer for it inside of baseclient, what might be better placed as a project solution.

With redux combine there is the opportunity to chain multiple reducers. To configure it, add `PROJECT_REDUCER_PATH` pointing to main project reducer file to your project `.env` file (like this already done for `PROJECT_MAIN_PATH` or `PROJECT_MAIN_CLASS` etc.) like this: 
```
# The path to the project main reducer (!!! relative from ProjectMain path)
PROJECT_REDUCER_PATH=src/store/my-project-reducer
```
This way you can extent the already existing global state of baseclient by your own redux state keys.

In addition:
* wrap all keys defined inside of webpack's `DefinePlugin` into 'process.env'` to ensure that all variables can be accessed globally by client.
* remove some dublicates (e.g. `TARGET`, which can be actually obtained from node environment)
* Change port of puppeteer test server to avoid colliding with possibly running shogun-boot backend which also occupies port 8000

Thanks for the collaboration @dnlkoch 👑 

Please take a note @terrestris/devs 