### PR TITLE
Transform init center prop when projection has changed

### DIFF
--- a/src/ProjectMain.tsx
+++ b/src/ProjectMain.tsx
@@ -131,7 +131,6 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
 
     const appContextUtil = getAppContextUtil();
     const measureToolsEnabled = appContextUtil.measureToolsEnabled(activeModules);
-
     // apply possibly given permalink
     PermalinkUtil.applyLink(map);
 

--- a/src/ProjectMain.tsx
+++ b/src/ProjectMain.tsx
@@ -32,7 +32,8 @@ const mapStateToProps = (state: any) => {
     loading: state.loadingQueue.loading,
     appContext: state.appContext,
     mapScales: state.mapScales,
-    addLayerWindowVisible: state.appState.addLayerWindowVisible
+    addLayerWindowVisible: state.appState.addLayerWindowVisible,
+    projection: state.mapView.present.projection
   };
 };
 
@@ -51,6 +52,7 @@ export interface MainProps extends Partial<DefaultMainProps> {
   activeModules: object[];
   mapScales: number[];
   t: (arg: string) => string;
+  projection: string;
 }
 
 export interface MainState {
@@ -131,6 +133,7 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
 
     const appContextUtil = getAppContextUtil();
     const measureToolsEnabled = appContextUtil.measureToolsEnabled(activeModules);
+
     // apply possibly given permalink
     PermalinkUtil.applyLink(map);
 

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -470,6 +470,18 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
     const tools: any[] = [];
     const mapConfig = ObjectUtil.getValue('mapConfig', appContext);
     const isMobileClient = isMobile();
+    const initProjection = mapConfig.projection.indexOf('EPSG:') < 0 ?
+      'EPSG:' + mapConfig.projection :
+      mapConfig.projection;
+    const currentProjection = map.getView().getProjection().getCode();
+    let center = [
+      mapConfig.center.x,
+      mapConfig.center.y
+    ];
+
+    if (initProjection !== currentProjection) {
+      center = transform(center, initProjection, currentProjection);
+    }
 
     activeModules.forEach((module: any) => {
       if (module.hidden) {
@@ -502,10 +514,7 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
           return;
         case 'shogun-button-zoomtoextent':
           tools.push(<ZoomToExtentButton
-            center={[
-              mapConfig.center.x,
-              mapConfig.center.y
-            ]}
+            center={center}
             zoom={mapConfig.zoom}
             map={map}
             key="3"


### PR DESCRIPTION
### Bug
After projection change, the `zoomToExtent` Button still zoomed to the coordinates in old (initial) projection.

### Fix
- Listen to projection change by adding a respective prop to redux' `mapStateToProps`
- Transform center coordinate in `getToolsforToolbar` if projection has changed.

Not sure how I could improve the first step, please review @terrestris/devs 
