### PR TITLE
Adds react-geo-measure-tooltip to textColor exception

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -11,7 +11,7 @@ body {
  * Make most of the text elements use the defined text color.
  * This list may be incomplete
  */
-p, b, h1, h2, h3, h4, h5, em, span:not(.fa), div:not(.ant-tooltip-inner), a:not(.link), li {
+p, b, h1, h2, h3, h4, h5, em, span:not(.fa), div:not(.ant-tooltip-inner, .react-geo-measure-tooltip), a:not(.link), li {
   color: var(--textColor) !important;
 }
 


### PR DESCRIPTION
This PR

- adds `react-geo-measure-tooltip` class to `--textColor` exception because previously the text of these tooltips was displayed in the color of the `--textColor` (e.g. black on grey background) and could not be overwritten in the project

@terrestris/devs please reveiw