### PR TITLE
Apply properties crossOrigin and className from layer configuration

### DIFF
--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -239,17 +239,17 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
     let tileGrid;
     if (tileSize && resolutions && tileOrigin) {
       tileGrid = new OlTileGrid({
-        resolutions: resolutions,
+        resolutions,
         tileSize: [tileSize, tileSize],
         origin: tileOrigin
       });
     }
 
-    const layerSource = new OlTileWMS({
-      url: url,
-      tileGrid: tileGrid,
+    const source = new OlTileWMS({
+      url,
+      tileGrid,
       attributions: attribution,
-      projection: projection,
+      projection,
       params: {
         'LAYERS': layerNames,
         'TILED': requestWithTiled,
@@ -259,7 +259,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
     });
 
     if (layer.type === 'WMSTime') {
-      layerSource.getParams().TIME = moment(moment.now()).format(defaultFormat);
+      source.getParams().TIME = moment(moment.now()).format(defaultFormat);
     }
 
     const tileLayer = new OlTileLayer({
@@ -312,8 +312,8 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       propertyConfig
     } = layer.clientConfig;
 
-    const layerSource = new OlImageWMS({
-      url: url,
+    const source = new OlImageWMS({
+      url,
       attributions: attribution,
       params: {
         'LAYERS': layerNames,

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -209,7 +209,6 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
     const {
       url,
       layerNames,
-      crossOrigin,
       requestWithTiled,
       transparent = true,
       attribution,
@@ -230,6 +229,8 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       propertyConfig,
       hoverTemplate,
       minResolution,
+      className,
+      crossOrigin,
       maxResolution
     } = clientConfig || {};
 
@@ -254,7 +255,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
         'TILED': requestWithTiled,
         'TRANSPARENT': transparent
       },
-      crossOrigin: crossOrigin
+      crossOrigin
     });
 
     if (layer.type === 'WMSTime') {
@@ -262,10 +263,11 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
     }
 
     const tileLayer = new OlTileLayer({
-      source: layerSource,
-      opacity: opacity,
-      minResolution: minResolution,
-      maxResolution: maxResolution
+      source,
+      opacity,
+      minResolution,
+      maxResolution,
+      className
     });
 
     tileLayer.set('name', layer.name);
@@ -304,6 +306,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       hoverable,
       hoverTemplate,
       crossOrigin,
+      className,
       searchable,
       searchConfig,
       propertyConfig
@@ -316,12 +319,13 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
         'LAYERS': layerNames,
         'TRANSPARENT': true
       },
-      crossOrigin: crossOrigin
+      crossOrigin
     });
 
     const imageLayer = new OlImageLayer({
-      source: layerSource,
-      opacity: opacity
+      source,
+      opacity,
+      className
     });
 
     imageLayer.set('name', layer.name);
@@ -356,7 +360,9 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       opacity,
       searchable,
       searchConfig,
-      propertyConfig
+      propertyConfig,
+      crossOrigin,
+      className
     } = layer.clientConfig || {};
 
     const wmtsCapabilitiesParser = new OlWMTSCapabilities();
@@ -381,17 +387,19 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       projection: projection
     });
 
-    const wmtsSource = new OlSourceWMTS({
+    const source = new OlSourceWMTS({
       ...options,
       ...{
-        attributions: attribution
+        attributions: attribution,
+        crossOrigin
       }
     });
 
     const wmtsLayer = new OlTileLayer({
-      source: wmtsSource,
+      source,
       visible: false,
-      opacity: opacity
+      opacity,
+      className
     });
 
     wmtsLayer.set('name', layer.name);


### PR DESCRIPTION
As title says, properly parse and apply properties `crossOrigin` and `className` which can be set inside of layer's `clientConfig` object for shogun-boot based applications.

Please review @terrestris/devs 