### PR TITLE
Enable Feature Hovering For Vector Layers

### DIFF
--- a/src/component/Menu/FeatureInfo/FeatureInfo.tsx
+++ b/src/component/Menu/FeatureInfo/FeatureInfo.tsx
@@ -7,6 +7,7 @@ import OlStyleStyle from 'ol/style/Style';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleStroke from 'ol/style/Stroke';
 import OlStyleCircle from 'ol/style/Circle';
+import OlFeature from 'ol/Feature';
 
 import {
   Menu
@@ -293,7 +294,7 @@ export class FeatureInfo extends React.Component<FeatureInfoProps, FeatureInfoSt
   onMenuMouseEnter(evt: any) {
     const features = this.props.features[evt.key];
     const highlightSource = this.hoverVectorLayer.getSource();
-    highlightSource.addFeatures(features);
+    highlightSource.addFeatures(features.map((feat: OlFeature) => feat.clone()));
     this.resetHoverLayerStyle();
     this.setHoverLayerStyle(features);
   }


### PR DESCRIPTION
### Feature
This enables feature hovering for temporary vector layers, e.g. when a point layer has been imported client-side.  
The normal workflow and dispatch actions have been modified accordingly. 
Features of the `hoverVectorLayer` needs to be cloned before they are added to the map to avoid ol assertion errors.  

Thanks to @dnlkoch 

Please note: @terrestris/devs 

