### PR TITLE
Follow-up improvements of enabling hover vector features

### DIFF
--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -158,7 +158,7 @@ export class HsiButton extends React.Component<HsiButtonProps, HsiButtonStatePro
     } else {
       pixel = map.getEventPixel(olEvt.originalEvent);
     }
-    let internalVectorFeatures: any = {};
+    let internalVectorFeatures: {[name: string]: OlFeature[]} = {};
     const featureInfoUrls: string[] = [];
 
     // dispatch that any running HOVER process should be canceled

--- a/src/state/actions/RemoteFeatureAction.ts
+++ b/src/state/actions/RemoteFeatureAction.ts
@@ -162,8 +162,11 @@ export function fetchFeatures(type: string, urls: string[], passThroughOpts: any
             Object.assign(resultFeatures, feat.features);
           }
         });
-        resultFeatures = {...resultFeatures,...passThroughOpts.internalVectorFeatures};
+        resultFeatures = { ...resultFeatures, ...passThroughOpts.internalVectorFeatures };
 
+        if (isEmpty(passThroughOpts.internalVectorFeatures)) {
+          delete passThroughOpts.internalVectorFeatures;
+        }
         // As soon as all single actions are fulfilled, write the combined
         // features into the state.
         return dispatch(fetchedFeatures(type, resultFeatures, passThroughOpts));

--- a/src/state/actions/RemoteFeatureAction.ts
+++ b/src/state/actions/RemoteFeatureAction.ts
@@ -164,7 +164,7 @@ export function fetchFeatures(type: string, urls: string[], passThroughOpts: any
         });
         resultFeatures = { ...resultFeatures, ...passThroughOpts.internalVectorFeatures };
 
-        if (isEmpty(passThroughOpts.internalVectorFeatures)) {
+        if (!isEmpty(passThroughOpts.internalVectorFeatures)) {
           delete passThroughOpts.internalVectorFeatures;
         }
         // As soon as all single actions are fulfilled, write the combined


### PR DESCRIPTION
Follow up fix of #798   
- fix type of internalVectorFeatures
- delete property `internalVectorFeatures` from `passThroughOpts` if empty

@dnlkoch please have a look.