### PR TITLE
Set shogunId property on layer

### DIFF
--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -271,6 +271,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       className
     });
 
+    tileLayer.set('shogunId', layer.id);
     tileLayer.set('name', layer.name);
     tileLayer.set('hoverable', hoverable);
     tileLayer.set('hoverTemplate', hoverTemplate);
@@ -331,6 +332,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       className
     });
 
+    imageLayer.set('shogunId', layer.id);
     imageLayer.set('name', layer.name);
     imageLayer.set('hoverable', hoverable);
     imageLayer.set('hoverTemplate', hoverTemplate);
@@ -407,6 +409,7 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
       className
     });
 
+    wmtsLayer.set('shogunId', layer.id);
     wmtsLayer.set('name', layer.name);
     wmtsLayer.set('type', layer.type);
     wmtsLayer.set('searchable', searchable);


### PR DESCRIPTION
Set `shogunId` property coming from shogun-boot context on layer. This way, the connection between shogun layer entities and openlayers layer instances can be achieved much more easier via `layer.get('shogunId') === layerEntity.id`, which makes filtering  or search more robust.

Please review @terrestris/devs 