### PR TITLE
Re-enable hover/pressed button color

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -30,10 +30,17 @@ div.imprint.footer-element {
 }
 
 /**
- * Apply the baseColor to various elements
+ * Apply the toolbarColor to various elements
  */
 button, .ant-collapse-header, .react-geo-titlebar {
-  background-color: var(--baseColor) !important;
+  background-color: var(--toolbarColor) !important;
+}
+
+/**
+ * Apply CSS filter brightness for hovered and pressed buttons
+ */
+button:hover, .react-geo-togglebutton.btn-pressed {
+    filter: brightness(0.8);
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/Main.css
+++ b/src/Main.css
@@ -30,10 +30,10 @@ div.imprint.footer-element {
 }
 
 /**
- * Apply the toolbarColor to various elements
+ * Apply the baseColor to various elements
  */
 button, .ant-collapse-header, .react-geo-titlebar {
-  background-color: var(--toolbarColor) !important;
+  background-color: var(--baseColor) !important;
 }
 
 /**


### PR DESCRIPTION
### Bug
Buttons hover effect and `ToggleButton's` pressed color is broken.
(Possibly after `background-color` is overwritten by CSS-var in `Main.css`).

## Fix
Make use of CSS filter `brightness` to get darker colors when hovering buttons or pressed status is active.  

@Thanks @weskamm 

@terrestris/devs please have a look.