### PR TITLE
Use text-overflow ellipsis to avoid cropped permalink links

### DIFF
--- a/src/component/Permalink/Permalink.css
+++ b/src/component/Permalink/Permalink.css
@@ -13,6 +13,7 @@
   border: solid 1px var(--baseColor);
   border-radius: 2px;
   padding: 0 5px;
+  text-overflow: ellipsis;
 }
 
 .permalink input:focus {


### PR DESCRIPTION
See in title.

![image](https://user-images.githubusercontent.com/3939355/117663923-78d4e000-b1a1-11eb-8797-4ace8edfc2ac.png)

Please review @terrestris/devs 
