### PR TITLE
Introduce "Zoom to layer resolution" context menu entry

### DIFF
--- a/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -18,8 +18,8 @@ interface DefaultLayerLegendAccordionNodeProps {
   layer: any;
 }
 
-interface LayerLegendAccordionNodeProps extends Partial<DefaultLayerLegendAccordionNodeProps>{
-  t: (arg: string) => {};
+interface LayerLegendAccordionNodeProps extends Partial<DefaultLayerLegendAccordionNodeProps> {
+  t: (arg: string) => string;
   map: any;
 }
 
@@ -34,7 +34,7 @@ interface LayerLegendAccordionNodeState {
  * @extends React.Component
  */
 // eslint-disable-next-line
- export default class LayerLegendAccordionNode extends React.Component<LayerLegendAccordionNodeProps, LayerLegendAccordionNodeState> {
+export default class LayerLegendAccordionNode extends React.Component<LayerLegendAccordionNodeProps, LayerLegendAccordionNodeState> {
 
   public static defaultProps: DefaultLayerLegendAccordionNodeProps = {
     layer: null
@@ -265,7 +265,8 @@ interface LayerLegendAccordionNodeState {
             <LayerTreeDropdownContextMenu
               map={this.props.map}
               layer={layer}
-              t={t} />
+              t={t}
+            />
           }
           {(layer.get('type') === 'WMSTime') &&
             <LayerTreeApplyTimeInterval

--- a/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
+++ b/src/component/container/LayerLegendAccordion/LayerLegendAccordion.tsx
@@ -40,7 +40,7 @@ interface DefaultLayerLegendAccordionProps {
 interface LayerLegendAccordionProps extends Partial<DefaultLayerLegendAccordionProps> {
   map: any;
   dispatch: (arg: any) => void;
-  t: (arg: string) => {};
+  t: (arg: string) => string;
 }
 
 interface LayerLegendAccordionState {

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -48,8 +48,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       TRANSPARENT: true
     },
     dispatch: () => {},
-    showApplyTimeInterval: true,
-    showZoomToLayerExtent: true,
+    showApplyTimeInterval: false,
+    showZoomToLayerExtent: false,
     showZoomToLayerResolution: false
   };
 

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -30,7 +30,7 @@ interface DefaultLayerTreeClassicProps {
 
 interface LayerTreeClassicProps extends Partial<DefaultLayerTreeClassicProps> {
   map: any;
-  t: (arg: string) => any;
+  t: (arg: string) => string;
   treeNodeFilter?: (value: any, index: number, array: any[]) => boolean;
 }
 

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
+import React from 'react';
 
 import OlLayerGroup from 'ol/layer/Group';
 import OlLayer from 'ol/layer/Base';
+import OlMap from 'ol/Map';
 
 import LayerTree from '@terrestris/react-geo/dist/LayerTree/LayerTree';
 import Legend from '@terrestris/react-geo/dist/Legend/Legend';
@@ -10,7 +11,7 @@ import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleB
 import LayerTreeApplyTimeInterval from '../../container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval';
 import LayerTreeDropdownContextMenu from '../../container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu';
 
-import {MapUtil} from '@terrestris/ol-util';
+import { MapUtil } from '@terrestris/ol-util';
 
 import './LayerTreeClassic.css';
 
@@ -28,55 +29,40 @@ interface DefaultLayerTreeClassicProps {
   showApplyTimeInterval: boolean;
 }
 
-interface LayerTreeClassicProps extends Partial<DefaultLayerTreeClassicProps> {
-  map: any;
+interface LayerTreeClassicProps {
+  map: OlMap;
   t: (arg: string) => string;
   treeNodeFilter?: (value: any, index: number, array: any[]) => boolean;
 }
+
+type ComponentProps = DefaultLayerTreeClassicProps & LayerTreeClassicProps;
 
 /**
  * Class representing a classic LayerTree with included Legend.
  *
  * @class LayerTreeClassic
- * @extends React.Component
  */
-export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
-
-  public static defaultProps: DefaultLayerTreeClassicProps = {
-    extraLegendParams: {
-      LEGEND_OPTIONS: 'fontAntiAliasing:true;forceLabels:on;fontName:DejaVu Sans Condensed',
-      TRANSPARENT: true
-    },
-    dispatch: () => {},
-    showApplyTimeInterval: false,
-    showZoomToLayerExtent: false,
-    showZoomToLayerResolution: false
-  };
-
-  /**
-   * @constructs LayerTreeClassic
-   */
-  constructor(props: LayerTreeClassicProps) {
-    super(props);
-
-    this.onHideLayerTree = this.onHideLayerTree.bind(this);
-    this.showContextMenu = this.showContextMenu.bind(this);
-  }
+export const LayerTreeClassic: React.FC<ComponentProps> = ({
+  extraLegendParams = {
+    LEGEND_OPTIONS: 'fontAntiAliasing:true;forceLabels:on;fontName:DejaVu Sans Condensed',
+    TRANSPARENT: true
+  },
+  dispatch,
+  showContextMenu,
+  showApplyTimeInterval = false,
+  showZoomToLayerExtent = false,
+  showZoomToLayerResolution = false,
+  treeNodeFilter,
+  t,
+  map
+}): JSX.Element => {
 
   /**
-   * Currently only two context menu entries (description and metadata) are
-   * expected. This check should be possibly extended in case of further entries
-   * arrive.
+   * Checks if the layer's context menu is available for the certain layer.
    *
    * @param layer Layer entry.
    */
-  showContextMenu(layer: OlLayer) {
-
-    const {
-      showZoomToLayerExtent,
-      showZoomToLayerResolution,
-      showContextMenu
-    } = this.props;
+  const contextMenuAvailable = (layer: OlLayer) => {
 
     if (_isBoolean(showContextMenu)) {
       return showContextMenu;
@@ -87,22 +73,14 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       layer.get('showMetadataInClient');
 
     return showDescription || showMetadata || showZoomToLayerExtent || showZoomToLayerResolution;
-  }
+  };
 
   /**
    * Custom tree node renderer function
-   * @param {any} layer The OpenLayers layer or LayerGroup the tree node
+   * @param {OlLayer} layer The OpenLayers layer or LayerGroup the tree node
    *   should be rendered for
    */
-  treeNodeTitleRenderer(layer: OlLayer) {
-    const {
-      map,
-      extraLegendParams,
-      t,
-      showZoomToLayerExtent,
-      showZoomToLayerResolution,
-      showApplyTimeInterval
-    } = this.props;
+  const treeNodeTitleRenderer = (layer: OlLayer) => {
 
     const unit = map.getView().getProjection().getUnits();
     const scale = MapUtil.getScaleForResolution(map.getView().getResolution(), unit);
@@ -127,9 +105,9 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
               }
             </span>
             <div className='classic-tree-node-header-buttons'>
-              {(this.showContextMenu(layer) && layer instanceof OlLayer) &&
+              {(contextMenuAvailable(layer) && layer instanceof OlLayer) &&
                 <LayerTreeDropdownContextMenu
-                  map={this.props.map}
+                  map={map}
                   layer={layer}
                   showZoomToLayerExtent={showZoomToLayerExtent}
                   showZoomToLayerResolution={showZoomToLayerResolution}
@@ -137,7 +115,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
               }
               {(showApplyTimeInterval && layer.get('type') === 'WMSTime') &&
                 <LayerTreeApplyTimeInterval
-                  map={this.props.map}
+                  map={map}
                   layer={layer}
                   t={t}
                 />
@@ -165,37 +143,24 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
         </div>
       );
     }
-  }
+  };
 
-  onHideLayerTree() {
-    this.props.dispatch(hideLayerTree());
-  }
-
-  /**
-   * The render function
-   */
-  render() {
-    const {
-      map
-    } = this.props;
-
-    return (
-      <div className='layer-tree-classic'>
-        <SimpleButton
-          iconName="fas fa-times"
-          shape="circle"
-          className="layer-tree-classic-close-button"
-          size="small"
-          onClick={this.onHideLayerTree}
-        />
-        <LayerTree
-          map={map}
-          nodeTitleRenderer={this.treeNodeTitleRenderer.bind(this)}
-          filterFunction={this.props.treeNodeFilter}
-        />
-      </div>
-    );
-  }
-}
+  return (
+    <div className='layer-tree-classic'>
+      <SimpleButton
+        iconName="fas fa-times"
+        shape="circle"
+        className="layer-tree-classic-close-button"
+        size="small"
+        onClick={() => dispatch(hideLayerTree())}
+      />
+      <LayerTree
+        map={map}
+        nodeTitleRenderer={treeNodeTitleRenderer}
+        filterFunction={treeNodeFilter}
+      />
+    </div>
+  );
+};
 
 export default LayerTreeClassic;

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -24,6 +24,7 @@ interface DefaultLayerTreeClassicProps {
   dispatch: (arg: any) => void;
   showContextMenu?: boolean;
   showZoomToLayerExtent?: boolean;
+  showZoomToLayerResolution?: boolean;
   showApplyTimeInterval: boolean;
 }
 
@@ -48,7 +49,8 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
     },
     dispatch: () => {},
     showApplyTimeInterval: true,
-    showZoomToLayerExtent: true
+    showZoomToLayerExtent: true,
+    showZoomToLayerResolution: false
   };
 
   /**
@@ -72,6 +74,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
 
     const {
       showZoomToLayerExtent,
+      showZoomToLayerResolution,
       showContextMenu
     } = this.props;
 
@@ -83,7 +86,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
     const showMetadata = !_isEmpty(layer.get('metadataIdentifier')) &&
       layer.get('showMetadataInClient');
 
-    return showDescription || showMetadata || showZoomToLayerExtent;
+    return showDescription || showMetadata || showZoomToLayerExtent || showZoomToLayerResolution;
   }
 
   /**
@@ -97,6 +100,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
       extraLegendParams,
       t,
       showZoomToLayerExtent,
+      showZoomToLayerResolution,
       showApplyTimeInterval
     } = this.props;
 
@@ -128,6 +132,7 @@ export class LayerTreeClassic extends React.Component<LayerTreeClassicProps> {
                   map={this.props.map}
                   layer={layer}
                   showZoomToLayerExtent={showZoomToLayerExtent}
+                  showZoomToLayerResolution={showZoomToLayerResolution}
                   t={t} />
               }
               {(showApplyTimeInterval && layer.get('type') === 'WMSTime') &&

--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
@@ -130,7 +130,6 @@ export const LayerTreeDropdownContextMenu: React.FC<ComponentProps> = ({
    * Zooms map view to max layer resolution.
    */
   const zoomToLayerResolution = (): void => {
-
     const mapResolutions = map.getView().getResolutions();
     let maxResolution = layer.getMaxResolution();
 

--- a/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
+++ b/src/component/container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu.tsx
@@ -53,7 +53,7 @@ export class LayerTreeDropdownContextMenu extends
 
 
   public static defaultProps: LayerTreeDropdownContextMenuDefaultProps = {
-    showZoomToLayerExtent: true,
+    showZoomToLayerExtent: false,
     showZoomToLayerResolution: false
   };
   /**

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -161,6 +161,7 @@
     "layerSettingsTooltipText": "Eigenschaften",
     "layerMetadataText": "Metadaten anzeigen",
     "layerZoomToExtent": "Auf Layerausdehnung zoomen",
+    "layerZoomToResolution": "Auf minimal sichtbare Ausdehnung zoomen",
     "extentError": "Konnte nicht auf die Layerausdehnung zoomen"
   },
   "LayerTreeApplyTimeInterval": {

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -160,6 +160,7 @@
     "layerSettingsTooltipText": "Properties",
     "layerMetadataText": "Display metadata",
     "layerZoomToExtent": "Zoom to layer extent",
+    "layerZoomToResolution": "Zoom to minimal layer resolution",
     "extentError": "Could not zoom to the layer extent"
   },
   "LayerTreeApplyTimeInterval": {


### PR DESCRIPTION
* Add configurable layer context menu entry "Zoom to layer resolution" (default is false)
  * If set to true, determines configured layer min resolution and set its value on the map
  * If no value cannot be determined, zooms map to it's minimal available scale (zoom = 0)

* Please note:
  * Default value of `showZoomToLayerExtent` and `showApplyTimeInterval` configs was changed to `false`. So from now, the configs must be explicitily provided by component instantiation if the context menu entries should be shown in client.

Also rewrites `LayerTreeClassic` and `LayerTreeDropdownContextMenu` to functional components.

Please review @terrestris/devs 