### PR TITLE
Introduce client component config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add this CHANGELOG file ([#811](https://github.com/terrestris/react-geo-baseclient/pull/811)).
+- Introduce client component config ([#815](https://github.com/terrestris/react-geo-baseclient/pull/815))
 
 ### Changed
 

--- a/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
+++ b/src/component/LayerLegendAccordionTreeNode/LayerLegendAccordionTreeNode.tsx
@@ -11,6 +11,8 @@ import LayerTransparencySlider from '@terrestris/react-geo/dist/Slider/LayerTran
 import LayerTreeDropdownContextMenu from '../container/LayerTreeDropdownContextMenu/LayerTreeDropdownContextMenu';
 import LayerTreeApplyTimeInterval from '../container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval';
 
+import config from '../../config/config';
+
 import './LayerLegendAccordionTreeNode.css';
 
 // default props
@@ -206,7 +208,7 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
           <Tooltip
             title={t('LayerLegendAccordion.toggleVisibilityTooltipText')}
             placement="top"
-            mouseEnterDelay={0.5}
+            {...config.tooltipProps}
           >
             <span
               className={visibilitySpanClass}
@@ -216,7 +218,7 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
           <Tooltip
             title={layer.get('name')}
             placement="top"
-            mouseEnterDelay={0.5}
+            {...config.tooltipProps}
           >
             <span
               className="layer-tree-node-title-layername"
@@ -239,7 +241,7 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
           <Tooltip
             title={t('LayerLegendAccordion.toggleVisibilityTooltipText')}
             placement="top"
-            mouseEnterDelay={0.5}
+            {...config.tooltipProps}
           >
             <span
               className={visibilitySpanClass}
@@ -249,7 +251,7 @@ export default class LayerLegendAccordionNode extends React.Component<LayerLegen
           <Tooltip
             title={layer.get('name')}
             placement="top"
-            mouseEnterDelay={0.5}
+            {...config.tooltipProps}
           >
             <span
               className="layer-tree-node-title-layername"

--- a/src/component/container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval.tsx
+++ b/src/component/container/LayerTreeApplyTimeInterval/LayerTreeApplyTimeInterval.tsx
@@ -6,6 +6,8 @@ import OlLayerBase from 'ol/layer/Base';
 import { Tooltip } from 'antd';
 import moment from 'moment';
 
+import config from '../../../config/config';
+
 import {
   setStartDate,
   setEndDate,
@@ -115,7 +117,7 @@ LayerTreeApplyTimeIntervalState
         <Tooltip
           title={t('LayerTreeApplyTimeInterval.setTimeLineToLayerInterval')}
           placement="right"
-          mouseEnterDelay={0.5}
+          {...config.tooltipProps}
         >
           <span
             className={className}

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,4 +1,4 @@
-const nodeEnv = typeof(process.env.NODE_ENV) !== 'undefined' ? process.env.NODE_ENV : undefined;
+const nodeEnv = typeof (process.env.NODE_ENV) !== 'undefined' ? process.env.NODE_ENV : undefined;
 const appPrefix = (typeof (process.env.APP_PREFIX) !== 'undefined' &&
   nodeEnv && nodeEnv.indexOf('production') > -1) ? process.env.APP_PREFIX : '/';
 const basePath = window.location.origin + appPrefix;
@@ -7,7 +7,7 @@ const buildPath = window.location.origin +
 const shogun2Path = basePath + 'rest/projectapps/';
 const shogunBootPath = basePath + 'applications/';
 let staticPath = basePath + 'resources/appContext.json';
-let localePath =  basePath + 'resources/i18n/{{lng}}.json';
+let localePath = basePath + 'resources/i18n/{{lng}}.json';
 const appMode = typeof (process.env.APP_MODE) !== 'undefined' ? process.env.APP_MODE : '';
 
 if (nodeEnv && nodeEnv.indexOf('production') > -1) {
@@ -34,7 +34,14 @@ if (appMode.indexOf('boot') > -1) {
   applicationPath = basePath + 'applications';
 }
 
+const clientComponentConfig = {
+  tooltipProps: {
+    mouseEnterDelay: .5
+  }
+};
+
 export default {
+  // path configuration
   appContextPath,
   layerPath,
   userPath,
@@ -42,12 +49,14 @@ export default {
   geoserverActionPath: `${basePath}geoserver.action`,
   appInfoPath: `${basePath}info/app`,
   locale: localePath,
-  getBasePath: function (){
+  getBasePath: function() {
     return basePath;
   },
   logoutUrl: `${basePath}sso/logout`,
   printAction: `${basePath}print/print`,
   printCreateUrlAction: `${basePath}print/createUrl.action`,
   printUrlAction: `${basePath}print/doPrint.action`,
-  printGetResultAction: `${basePath}print/getPrintResult.action`
+  printGetResultAction: `${basePath}print/getPrintResult.action`,
+  // client / component configuration
+  ...clientComponentConfig
 };


### PR DESCRIPTION
Introduce `clientComponentConfig` object which can be used to manage some app-wide common settings (like tooltip delay) at one place.

Currently includes only `tooltipProps` config with `mouseEnterDelay` key and can be surely extended by further needed entries.

Please review @terrestris/devs 