### PR TITLE
Don't override color of icons in antd notification elements

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -11,7 +11,11 @@ body {
  * Make most of the text elements use the defined text color.
  * This list may be incomplete
  */
-p, b, h1, h2, h3, h4, h5, em, span:not(.fa), div:not(.ant-tooltip-inner, .react-geo-measure-tooltip), a:not(.link), li {
+p, b, h1, h2, h3, h4, h5, em,
+div:not(.ant-tooltip-inner, .react-geo-measure-tooltip),
+span:not(.fa, .anticon.ant-alert-icon, .anticon.anticon-info-circle, .ant-notification-notice-icon),
+a:not(.link),
+li {
   color: var(--textColor) !important;
 }
 


### PR DESCRIPTION
Excludes override for anticon images color from global CSS.

before:
![image](https://user-images.githubusercontent.com/3939355/118652805-3df92a80-b7e7-11eb-8d13-880cb3711e74.png) 
after:
![image](https://user-images.githubusercontent.com/3939355/118652575-08ecd800-b7e7-11eb-9d43-707bfd7b7726.png)

Please review @terrestris/devs 
