### PR TITLE
HSIButton refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-- GetFeatureInfo components refactoring ([#810](https://github.com/terrestris/react-geo-baseclient/pull/811))
+- `GetFeatureInfo` components refactoring ([#810](https://github.com/terrestris/react-geo-baseclient/pull/811))
   - Refactored all `GetFeatureInfo` related components to react's functional component
   - 🚨 Replaced `width` property set on GetFeatureInfo overlay menu by `maxWidth` (increased from 200 to 350px) to prevent cropped titles on long layer names
-- Introduce "Zoom to layer resolution" context menu entry ([#809](https://github.com/terrestris/react-geo-baseclient/pull/809))
+- `HSIButton` component refactoring ([#817](https://github.com/terrestris/react-geo-baseclient/pull/817))
+  - 🚨 `t` was removed from class props
+  - 🚨 `dispatch` was removed from class props, react-redux hook will be used instead
+  - 🚨 default value for `tooltip` is set to `Feature Info`
+  - 🚨 default value for `tooltipPlacement` is set to `right`
+  - added additional optional propery `onToggleCb` enabling custom logic on HSIButton activation (e.g. show notification about tool state, queryable layers etc.)
+- Introduce `"Zoom to layer resolution"` context menu entry ([#809](https://github.com/terrestris/react-geo-baseclient/pull/809))
   - Add configurable layer context menu entry "Zoom to layer resolution" (default is false)
   - 🚨 Default value of `showZoomToLayerExtent` and `showApplyTimeInterval` configs was changed to `false`. So from now, the configs must be explicitily provided by component instantiation if the context menu entries should be shown in client.
 

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -83,6 +83,9 @@ export const HsiButton: React.FC<ComponentProps> = ({
       } else {
         map.on('pointerrest', getInfo);
       }
+      if (onToggleCb) {
+        onToggleCb();
+      }
       // remove possible hover artifacts
       dispatch(clearFeatures('HOVER'));
     }

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -1,14 +1,17 @@
-import * as React from 'react';
-import { connect } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 import ToggleButton, { ToggleButtonProps } from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
 
 import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+import OlProjection from 'ol/proj/Projection';
 import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceVector from 'ol/source/Vector';
 import OlFeature from 'ol/Feature';
 import OlLayer from 'ol/layer/Layer';
+import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 
 import {
   abortFetchingFeatures,
@@ -16,124 +19,84 @@ import {
   clearFeatures
 } from '../../../state/actions/RemoteFeatureAction';
 
+import { BaseClientState } from '../../../state/reducers/Reducer';
+
 interface DefaultHsiButtonProps extends ToggleButtonProps {
-  dataRange: any;
-  iconName: string;
+  dataRange?: any;
   /**
   * Whether the GFI control should requests all layers at a given coordinate
   * or just the uppermost one.
   * @type {Boolean}
   */
-  drillDown: boolean;
+  drillDown?: boolean;
   /**
    * Boolean to indicate that we do not want to hover but use click to retrieve
    * feature information
    */
-  getInfoByClick: boolean;
-}
-interface HsiButtonStateProps {
-  pressed: boolean;
+  getInfoByClick?: boolean;
+  /**
+   * Additional callback function which will be called when HSI button was toggled.
+   * Optional.
+   */
+  onToggleCb?: () => void;
 }
 
-interface HsiButtonProps extends Partial<DefaultHsiButtonProps> {
+interface HsiButtonProps {
   /**
    * OlMap this button is bound to.
    * @type {OlMap}
    */
   map: OlMap;
-
   /**
    * Button tooltip text
    */
   tooltip: string;
-
-  /**
-   * Translate function
-   */
-  t: (arg: string) => void;
-
-  /**
-   * Dispatch function
-   */
-  dispatch: (arg: any) => void;
 }
 
-/**
- * mapStateToProps - mapping state to props of HsiButton Component.
- *
- * @param {Object} state current state
- * @return {Object} mapped props
- */
-const mapStateToProps = (state: any) => {
-  return {
-    dataRange: state.dataRange
-  };
-};
+export type ComponentProps = DefaultHsiButtonProps & HsiButtonProps;
 
 /**
  * Class representing the HsiButton.
  *
  * @class HsiButton
- * @extends React.Component
  */
-export class HsiButton extends React.Component<HsiButtonProps, HsiButtonStateProps> {
+export const HsiButton: React.FC<ComponentProps> = ({
+  map,
+  drillDown = true,
+  type = 'primary',
+  shape = 'circle',
+  iconName = 'fas fa-info',
+  tooltip = 'Feature Info',
+  tooltipPlacement = 'right',
+  getInfoByClick = false,
+  onToggleCb = undefined,
+  ...passThroughProps
+}): React.ReactElement => {
 
-  /**
- * The default properties.
- */
-  public static defaultProps: DefaultHsiButtonProps = {
-    dataRange: {},
-    drillDown: true,
-    type: 'primary',
-    shape: 'circle',
-    iconName: 'fas fa-info',
-    getInfoByClick: false
-  };
+  const dispatch = useDispatch();
+  const dataRange = useSelector((state: BaseClientState) => state.dataRange);
 
-  constructor(props: HsiButtonProps) {
-    super(props);
-
-    this.state = {
-      pressed: false
-    };
-
-    // binds
-    this.onHsiToggle = this.onHsiToggle.bind(this);
-    this.getInfo = this.getInfo.bind(this);
-  }
-
-  /**
-   * Toggle handler of the HsiButton. (Un)registers `click`event on map on (un)toggle.
-   *
-   * @param {boolean} toggled Toggled state of the button.
-   */
-  onHsiToggle(toggled: boolean) {
-    const {
-      map,
-      dispatch,
-      getInfoByClick
-    } = this.props;
-
-    this.setState({
-      pressed: toggled
-    });
-    if (toggled) {
+  useEffect(() => {
+    if (passThroughProps.pressed) {
       if (getInfoByClick) {
-        map.on('click', this.getInfo);
+        map.on('click', getInfo);
       } else {
-        map.on('pointerrest', this.getInfo);
+        map.on('pointerrest', getInfo);
       }
-    } else {
-      if (getInfoByClick) {
-        map.un('click', this.getInfo);
-      } else {
-        map.un('pointerrest', this.getInfo);
-      }
-
       // remove possible hover artifacts
       dispatch(clearFeatures('HOVER'));
     }
-  }
+    return () => {
+      if (getInfoByClick) {
+        map.un('click', getInfo);
+      } else {
+        map.un('pointerrest', getInfo);
+      }
+      // remove possible hover artifacts
+      dispatch(clearFeatures('HOVER'));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [passThroughProps.pressed]);
 
   /**
    * Calls a GFI request to all hoverable (or the uppermost only, if `drillDown`
@@ -141,17 +104,10 @@ export class HsiButton extends React.Component<HsiButtonProps, HsiButtonStatePro
    *
    * @param {ol.MapEvent} olEvt The `pointerrest` event.
    */
-  getInfo(olEvt: any) {
-    const {
-      dispatch,
-      drillDown,
-      map,
-      dataRange,
-      getInfoByClick
-    } = this.props;
-    const mapView: any = map.getView();
-    const viewResolution: object = mapView.getResolution();
-    const viewProjection: object = mapView.getProjection();
+  const getInfo = (olEvt: OlMapBrowserEvent) => {
+    const mapView: OlView = map.getView();
+    const viewResolution: number = mapView.getResolution();
+    const viewProjection: OlProjection = mapView.getProjection();
     let pixel: number[];
     if (getInfoByClick) {
       pixel = olEvt.pixel;
@@ -164,17 +120,18 @@ export class HsiButton extends React.Component<HsiButtonProps, HsiButtonStatePro
     // dispatch that any running HOVER process should be canceled
     dispatch(abortFetchingFeatures('HOVER'));
 
-    olEvt.map.forEachLayerAtPixel(pixel, (layer: any) => {
+    map.forEachLayerAtPixel(pixel, (layer: OlLayer) => {
       const layerSource: any = layer.getSource();
-      const coordinate = map.getCoordinateFromPixel(pixel);
+      const coordinate: number[] = map.getCoordinateFromPixel(pixel);
 
       if (layer.getSource() instanceof OlSourceVector) {
         internalVectorFeatures[layer.get('name')] = [];
-        const internalFeatures = olEvt.map.getFeaturesAtPixel(pixel, (feature: OlFeature) => { }, {
+        const internalFeatures = olEvt.map.getFeaturesAtPixel(pixel, {
           layerFilter: (layerCandidate: OlLayer) => {
             return layerCandidate === layer;
           }
         });
+
         if (!internalFeatures.length) {
           return;
         }
@@ -187,98 +144,78 @@ export class HsiButton extends React.Component<HsiButtonProps, HsiButtonStatePro
       if (!layerSource.getFeatureInfoUrl) {
         return;
       }
-      const featureInfoUrl: string =
-        layer.get('type') === 'WMSTime'
-          ? layerSource
-            .getFeatureInfoUrl(
-              coordinate,
-              viewResolution,
-              viewProjection,
-              {
-                // TODO add check for json format availability
-                INFO_FORMAT: 'application/json',
-                FEATURE_COUNT: 999999999
-              }
-            )
-            .replace(
-              new RegExp('TIME=.*?&'),
-              `TIME=${escape(
-                dataRange.startDate.format(layer.get('timeFormat')) +
-                '/' +
-                dataRange.endDate.format(layer.get('timeFormat'))
-              )}&`
-            )
-          : layerSource.getFeatureInfoUrl(
-            map.getCoordinateFromPixel(pixel),
-            viewResolution,
-            viewProjection,
-            {
-              // TODO add check for json format availability
-              INFO_FORMAT: 'application/json',
-              FEATURE_COUNT: 10
-            }
-          );
+
+      let featureInfoUrl: string;
+      if (layer.get('type') === 'WMSTime') {
+        featureInfoUrl = layerSource.getFeatureInfoUrl(
+          coordinate,
+          viewResolution,
+          viewProjection,
+          {
+            // TODO add check for json format availability
+            INFO_FORMAT: 'application/json',
+            FEATURE_COUNT: 999999999
+          }
+        ).replace(
+          new RegExp('TIME=.*?&'),
+          `TIME=${escape(
+            dataRange.startDate.format(layer.get('timeFormat')) +
+            '/' +
+            dataRange.endDate.format(layer.get('timeFormat'))
+          )}&`
+        );
+      } else {
+        featureInfoUrl = layerSource.getFeatureInfoUrl(
+          map.getCoordinateFromPixel(pixel),
+          viewResolution,
+          viewProjection,
+          {
+            // TODO add check for json format availability
+            INFO_FORMAT: 'application/json',
+            FEATURE_COUNT: 10
+          }
+        );
+      }
 
       featureInfoUrls.push(featureInfoUrl);
       // stop iteration if drillDown is set to false.
       if (!drillDown) {
         return true;
       }
-    }, this, this.layerFilter);
+    }, { layerFilter });
 
     map.getTargetElement().style.cursor = featureInfoUrls.length > 0 ? 'wait' : '';
     dispatch(fetchFeatures(
       'HOVER', featureInfoUrls,
       { olEvt, internalVectorFeatures }
     ));
-  }
+  };
 
   /**
-   * Checks if a given layer is hoverable or not.
-   *
-   * @param {ol.layer.Base} layerCandidate The layer filter candidate.
-   * @return {Boolean} Whether the layer is hoverable or not.
-   */
-  layerFilter(layerCandidate: any) {
-    const source = layerCandidate.getSource();
-    const isHoverable = layerCandidate.get('hoverable');
-    const isSupportedHoverSource = source instanceof OlSourceImageWMS ||
+ * Checks if a given layer is hoverable or not.
+ *
+ * @param {ol.layer.Base} layerCandidate The layer filter candidate.
+ * @return {Boolean} Whether the layer is hoverable or not.
+ */
+  const layerFilter = (layerCandidate: OlLayer) => {
+    const source: any = layerCandidate.getSource();
+    const isHoverable: boolean = layerCandidate.get('hoverable');
+    const isSupportedHoverSource: boolean = source instanceof OlSourceImageWMS ||
       source instanceof OlSourceTileWMS || source instanceof OlSourceVector;
     return isHoverable && isSupportedHoverSource;
-  }
+  };
 
-  /**
-   * The render function.
-   */
-  render() {
-    const {
-      dataRange,
-      dispatch,
-      drillDown,
-      getInfoByClick,
-      iconName,
-      shape,
-      t,
-      tooltip,
-      tooltipPlacement,
-      type,
-      ...passThroughProps
-    } = this.props;
+  return (
+    <ToggleButton
+      type={type}
+      shape={shape}
+      iconName={iconName}
+      pressedIconName={iconName}
+      tooltip={tooltip}
+      tooltipPlacement={tooltipPlacement}
+      {...passThroughProps}
+    />
+  );
+};
 
-    return (
-      <ToggleButton
-        type={type}
-        shape={shape}
-        iconName={iconName}
-        pressedIconName={iconName}
-        tooltip={tooltip}
-        tooltipPlacement={tooltipPlacement}
-        onToggle={this.onHsiToggle}
-        pressed={this.state.pressed}
-        {...passThroughProps}
-      />
-    );
-  }
-}
-
-export default connect(mapStateToProps)(HsiButton);
+export default HsiButton;

--- a/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
+++ b/src/util/AppContextUtil/Shogun2AppContextUtil.tsx
@@ -547,7 +547,6 @@ class Shogun2AppContextUtil extends BaseAppContextUtil implements AppContextUtil
             key="5"
             tooltip={t('FeatureInfo.tooltip')}
             tooltipPlacement={'right'}
-            t={t}
             getInfoByClick={isMobileClient}
           />);
           return;

--- a/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
+++ b/src/util/AppContextUtil/ShogunBootAppContextUtil.tsx
@@ -506,7 +506,6 @@ class ShogunBootAppContextUtil extends BaseAppContextUtil implements AppContextU
             key="5"
             tooltip={t('FeatureInfo.tooltip')}
             tooltipPlacement={'right'}
-            t={t}
             getInfoByClick={isMobileClient}
           />);
           return;


### PR DESCRIPTION
* Refactor `HSIButton` class to react's functional component
* 🔥 Breaking changes:
  * `t` was removed from class props
  * `dispatch` was removed from class props, react-redux hook will be used instead
  * additional optional propery `onToggleCb` was added to enable custom logic on HSIButton activation (e.g. show notification about tool state, queryable layers etc.)
  * default value for `tooltip` is set to `Feature Info`
  * default value for `tooltipPlacement` is set to `right`

Existing application may will have to adapt class invocation as follows:
```
<HsiButton           
    iconName="my-icon" --> provide icon if no default (`icon-circle`) is desired
    pressedIconName="my-icon"  --> provide icon if no default (`icon-circle`) is desired
    tooltip="My tooltip" --> provide your tooltip (default is `Feature Info`)
    tooltipPlacement="bottom" --> adjust tooltip placement (default is `right`)
    name="info"
    map={map}            
    t={t} --> remove it, it's obsolete!
    dispatch={dispatchFn} --> remove it, it's obsolete!
    onToggleCb={myOptionalCallback} --> pass optional callback function on button toggle
    ...
  />
```

Please review @terrestris/devs 
