### PR TITLE
Diverse permalink fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reenable hover/pressed button color ([#805](https://github.com/terrestris/react-geo-baseclient/pull/805)).
 - Use `text-overflow:ellipsis` to avoid cropped permalink links ([#808](https://github.com/terrestris/react-geo-baseclient/pull/808)).
+- Fix call of default permalink `getLink` function and ensure that permalink is applied only once on first render ([#818](https://github.com/terrestris/react-geo-baseclient/pull/818))
+
 
 ## [1.0.0] - 2021-05-07
 

--- a/src/ProjectMain.tsx
+++ b/src/ProjectMain.tsx
@@ -99,6 +99,14 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
   }
 
   /**
+   *
+   */
+  componentDidMount() {
+    // apply possibly given permalink
+    PermalinkUtil.applyLink(this.props.map);
+  }
+
+  /**
    * apply custom style from app context
    */
   applyStyle() {
@@ -133,9 +141,6 @@ export class ProjectMain extends React.Component<MainProps, MainState> {
 
     const appContextUtil = getAppContextUtil();
     const measureToolsEnabled = appContextUtil.measureToolsEnabled(activeModules);
-
-    // apply possibly given permalink
-    PermalinkUtil.applyLink(map);
 
     const viewport = (
       <div className="viewport">

--- a/src/component/Permalink/Permalink.tsx
+++ b/src/component/Permalink/Permalink.tsx
@@ -18,7 +18,7 @@ interface PermalinkProps {
 export const Permalink: React.FC<PermalinkProps> = ({
   t,
   getLink
-}): JSX.Element => {
+}): React.ReactElement => {
 
   /**
    * Copy the permalink to clipboard

--- a/src/component/button/PermalinkButton/PermalinkButton.tsx
+++ b/src/component/button/PermalinkButton/PermalinkButton.tsx
@@ -16,7 +16,7 @@ interface DefaultPermalinkButtonProps extends SimpleButtonProps {
 interface BaseProps {
   map: any;
   t: (arg: string) => string;
-  getLink?: () => string;
+  getLink?: () => any;
   windowPosition?: [number, number];
 }
 
@@ -35,7 +35,7 @@ export const PermalinkButton: React.FC<PermalinkButtonProps> = ({
   map,
   tooltip,
   tooltipPlacement,
-  getLink,
+  getLink = undefined,
   windowPosition
 }) => {
 
@@ -73,7 +73,7 @@ export const PermalinkButton: React.FC<PermalinkButtonProps> = ({
           ]}
         >
           <Permalink
-            getLink={getLink ? getLink : PermalinkUtil.getLink(map)}
+            getLink={getLink ? getLink : () => PermalinkUtil.getLink(map)}
             t={t}
           />
         </Window>


### PR DESCRIPTION
## Description

* Fixes call of default `getLink` function (coming from `PermalinkUtil.getLink` method of `ol-util`)
* Ensures that permalink will be applied only once on first render


## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
