### PR TITLE
make `extraLegendParams` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reenable hover/pressed button color ([#805](https://github.com/terrestris/react-geo-baseclient/pull/805)).
 - Use `text-overflow:ellipsis` to avoid cropped permalink links ([#808](https://github.com/terrestris/react-geo-baseclient/pull/808)).
 - Fix call of default permalink `getLink` function and ensure that permalink is applied only once on first render ([#818](https://github.com/terrestris/react-geo-baseclient/pull/818))
+- Make `extraLegendParams` optional ([#819](https://github.com/terrestris/react-geo-baseclient/pull/819))
 
 
 ## [1.0.0] - 2021-05-07

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -21,7 +21,7 @@ import _isBoolean from 'lodash/isBoolean';
 import _isEmpty from 'lodash/isEmpty';
 
 interface DefaultLayerTreeClassicProps {
-  extraLegendParams: {};
+  extraLegendParams?: {};
   dispatch?: (arg: any) => void;
   showContextMenu?: boolean;
   showZoomToLayerExtent?: boolean;


### PR DESCRIPTION
## Description

As title says, make `extraLegendParams` optional. The default value is provided as well.

Please review @terrestris/devs 

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
