### PR TITLE
Fix toggling of `HsiButton` if called outside of toggle group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `text-overflow:ellipsis` to avoid cropped permalink links ([#808](https://github.com/terrestris/react-geo-baseclient/pull/808)).
 - Fix call of default permalink `getLink` function and ensure that permalink is applied only once on first render ([#818](https://github.com/terrestris/react-geo-baseclient/pull/818))
 - Make `extraLegendParams` optional ([#819](https://github.com/terrestris/react-geo-baseclient/pull/819))
+- Fix toggling of `HsiButton` ([#820](https://github.com/terrestris/react-geo-baseclient/pull/820))
 
 
 ## [1.0.0] - 2021-05-07

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import ToggleButton, { ToggleButtonProps } from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
@@ -76,8 +76,10 @@ export const HsiButton: React.FC<ComponentProps> = ({
   const dispatch = useDispatch();
   const dataRange = useSelector((state: BaseClientState) => state.dataRange);
 
+  const [pressed, setPressed] = useState<boolean>(false);
+
   useEffect(() => {
-    if (passThroughProps.pressed) {
+    if (pressed) {
       if (getInfoByClick) {
         map.on('click', getInfo);
       } else {
@@ -99,7 +101,14 @@ export const HsiButton: React.FC<ComponentProps> = ({
       dispatch(clearFeatures('HOVER'));
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [passThroughProps.pressed]);
+  }, [pressed]);
+
+  /**
+   * Manage toggled state.
+   */
+  const onHsiToggle = (toggled: boolean) => {
+    setPressed(toggled);
+  };
 
   /**
    * Calls a GFI request to all hoverable (or the uppermost only, if `drillDown`
@@ -216,6 +225,7 @@ export const HsiButton: React.FC<ComponentProps> = ({
       pressedIconName={iconName}
       tooltip={tooltip}
       tooltipPlacement={tooltipPlacement}
+      onToggle={onHsiToggle}
       {...passThroughProps}
     />
   );


### PR DESCRIPTION
## Description

Explicitily set `pressed` state on `HsiButton`, since `passThroughProps.pressed` prop is not available if button configured outside of any toggle group.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
