### PR TITLE
Fix parsing of layer tree nodes for shogun2-contex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix call of default permalink `getLink` function and ensure that permalink is applied only once on first render ([#818](https://github.com/terrestris/react-geo-baseclient/pull/818))
 - Make `extraLegendParams` optional ([#819](https://github.com/terrestris/react-geo-baseclient/pull/819))
 - Fix toggling of `HsiButton` ([#820](https://github.com/terrestris/react-geo-baseclient/pull/820))
+- Fix layer tree node parser for shogun2-based context ([#821](https://github.com/terrestris/react-geo-baseclient/pull/821))
 
 
 ## [1.0.0] - 2021-05-07


### PR DESCRIPTION
## Description

Layer nodes of layer tree can be serialized as id only. For this case, the existing logic must be adapted to ensure, that layer entity is completely available before tree nodes are being parsed.

Has relevance for shogun2-based projects only.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
