### PR TITLE
Fix display template for multisearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `extraLegendParams` optional ([#819](https://github.com/terrestris/react-geo-baseclient/pull/819))
 - Fix toggling of `HsiButton` ([#820](https://github.com/terrestris/react-geo-baseclient/pull/820))
 - Fix layer tree node parser for shogun2-based context ([#821](https://github.com/terrestris/react-geo-baseclient/pull/821))
+- Fix display template for multisearch ([#822](https://github.com/terrestris/react-geo-baseclient/pull/822))
 
 
 ## [1.0.0] - 2021-05-07


### PR DESCRIPTION
## Description
Previously only templated property keys placed between curly brackets (e.g. `{myProp}` were considered while displaying of search results. If display template includes some additional sings like brackets, quotation marks etc., these were ignored completely.

Example:
```
featureProps = {
  myProp1: 'humpty',
  myProp2: 'dumpty'
}
```
Template `{myProp1} {myProp2}` ---> Result `humpty dumpty`
Template `{myProp1} ({myProp2})!` ---> Result `humpty dumpty` (expected `humpty (dumpty)!` - parentheses and exclamation mark are ignored)

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
