### PR TITLE
Allow setting feature_count on HSI-Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `HSIButton`: Allow setting the feature_count property via prop.
+
 ## [2.0.0] - 2021-07-20
 
 ### Breaking changes

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -39,6 +39,10 @@ interface DefaultHsiButtonProps extends ToggleButtonProps {
    * Optional.
    */
   onToggleCb?: () => void;
+  /**
+   * Maximum number of features to retrieve. Defaults to 10.
+   */
+  featureCount?: number;
 }
 
 interface HsiButtonProps {
@@ -70,6 +74,7 @@ export const HsiButton: React.FC<ComponentProps> = ({
   tooltipPlacement = 'right',
   getInfoByClick = false,
   onToggleCb = undefined,
+  featureCount = 10,
   ...passThroughProps
 }): React.ReactElement => {
 
@@ -184,7 +189,7 @@ export const HsiButton: React.FC<ComponentProps> = ({
           {
             // TODO add check for json format availability
             INFO_FORMAT: 'application/json',
-            FEATURE_COUNT: 10
+            FEATURE_COUNT: featureCount
           }
         );
       }


### PR DESCRIPTION
## Description

This allows configuring the feature_count for the HSI-Button. Default remains 10.

@terrestris/devs please review

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
