### PR TITLE
Allow passing the className as prop for the Footer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `HSIButton`: Allow setting the feature_count property via prop.
+- `Footer`: Allow passing the `className` prop.
 
 ## [2.0.0] - 2021-07-20
 

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -20,10 +20,11 @@ import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 // default props
 interface DefaultFooterProps {
+  className: string;
   imprint: string;
 }
 
-interface FooterProps extends Partial<DefaultFooterProps>{
+interface FooterProps extends Partial<DefaultFooterProps> {
   map: any;
   t: (arg: string) => {};
   mapScales: number[];
@@ -193,6 +194,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
    */
   render() {
     const {
+      className,
       map,
       mapScales,
       projection,
@@ -201,7 +203,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
     } = this.props;
 
     return (
-      <footer className="footer">
+      <footer className={`footer ${className}`}>
         <div className="crscombo-col footer-element">
           <span>{t('CoordinateReferenceSystemCombo.label')}</span>
           <CoordinateReferenceSystemCombo


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This allows passing the `className` as prop for the `Footer` component.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
