### PR TITLE
Enable historyApiFallback

### DIFF
--- a/config/webpack.static.config.js
+++ b/config/webpack.static.config.js
@@ -49,6 +49,7 @@ const delayedConf = new Promise(function(resolve) {
   ];
 
   commonWebpackConfig.devServer = {
+    historyApiFallback: true,
     contentBase: path.join(__dirname, 'src'),
     disableHostCheck: true,
     host: '0.0.0.0',


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This enables the [historyApiFallback](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback) for the static webpack dev server configuration to enable routing via HTML5 history API.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
