### PR TITLE
Allow webpack proxy config through custom app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Allow webpack proxy config through custom app config([#841](https://github.com/terrestris/react-geo-baseclient/pull/841))
 - Update terrestris vectortiles lib ([#840](https://github.com/terrestris/react-geo-baseclient/pull/840))
 
 ## [2.0.1] - 2021-07-21

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SHOGUN_BACKEND_URL=http://localhost:9876/shogun2-webapp
 SHOGUN_USER=admin
 SHOGUN_PASS=
 
-# Config file containing keys for customized client title and loading mask logo
+# Config file containing keys for customized client title, proxy and loading mask logo
 CUSTOM_WEBPACK_CONFIG=myproject/config/webpack.config.js
 
 # Prefix/route of the application the client is served on, e.g. '/baseclient/' for 'https://myproject.org/baseclient/'

--- a/config/webpack.shogun-boot.config.js
+++ b/config/webpack.shogun-boot.config.js
@@ -167,7 +167,7 @@ const delayedConf =
             '/geoserver',
             '/print'
           ]
-        }],
+        }].concat(customAppConfig && customAppConfig.proxy ? customAppConfig.proxy : [{}]),
         publicPath: 'https://localhost:9091/'
       };
       return commonWebpackConfig;

--- a/config/webpack.shogun2.config.js
+++ b/config/webpack.shogun2.config.js
@@ -175,7 +175,7 @@ const delayedConf =
                   },
                   secure: false,
                   target: backendUrl
-                }],
+                }].concat(customAppConfig && customAppConfig.proxy ? customAppConfig.proxy : [{}]),
                 publicPath: 'https://localhost:9090/'
               };
               return commonWebpackConfig;

--- a/config/webpack.static.config.js
+++ b/config/webpack.static.config.js
@@ -56,7 +56,8 @@ const delayedConf = new Promise(function(resolve) {
     https: true,
     inline: true,
     port: 9090,
-    publicPath: 'https://localhost:9090/'
+    publicPath: 'https://localhost:9090/',
+    proxy: [].concat(customAppConfig && customAppConfig.proxy ? customAppConfig.proxy : [{}])
   };
   resolve(commonWebpackConfig);
 });


### PR DESCRIPTION
## Description

Allows the user to configure webpack proxy settings through the custom app config file

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
