### PR TITLE
Add user chip to header for login / logout purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added user chip to the header for login / logout
 - More CI-friendly build output ([#843](https://github.com/terrestris/react-geo-baseclient/pull/843))
 - Allow webpack proxy config through custom app config ([#841](https://github.com/terrestris/react-geo-baseclient/pull/841))
 - Update terrestris vectortiles lib ([#840](https://github.com/terrestris/react-geo-baseclient/pull/840))

--- a/src/component/container/Header/Header.css
+++ b/src/component/container/Header/Header.css
@@ -66,3 +66,13 @@
   padding: 0 5px 0 5px;
   cursor: pointer;
 }
+
+.app-header .user-chip {
+  display: flex;
+  padding: 0 10px 0 10px;
+  cursor: pointer;
+}
+
+.app-header .user-chip .user-name {
+  padding: 5px;
+}

--- a/src/component/container/Header/Header.tsx
+++ b/src/component/container/Header/Header.tsx
@@ -25,6 +25,9 @@ interface DefaultHeaderProps {
   showLanguageSelection: boolean;
   showMultiSearch: boolean;
   showNominatimSearch: boolean;
+  showUserChip: boolean;
+  userChipHandler: () => void;
+  userName: string;
 }
 
 interface HeaderProps extends Partial<DefaultHeaderProps> {
@@ -55,7 +58,10 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     showHelpButton: false,
     showLanguageSelection: true,
     showMultiSearch: true,
-    showNominatimSearch: true
+    showNominatimSearch: true,
+    showUserChip: false,
+    userChipHandler: undefined,
+    userName: undefined
   };
 
   /**
@@ -101,6 +107,9 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
       showLanguageSelection,
       showMultiSearch,
       showNominatimSearch,
+      showUserChip,
+      userChipHandler,
+      userName,
       wfsSearchBaseUrl,
       t
     } = this.props;
@@ -154,6 +163,24 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
         <div className="app-language-selection">
           <img src="de.png" alt="DE" onClick={() => this.onLanguageChange('de')} />
           <img src="en.png" alt="EN" onClick={() => this.onLanguageChange('en')} />
+        </div>
+        }
+        {showUserChip &&
+        <div className="user-chip">
+          <SimpleButton
+            name="userChipButton"
+            iconName="fas fa-user"
+            shape="circle"
+            tooltip={t('Header.userChipButtonTooltip') as string}
+            onClick={userChipHandler}
+            tooltipPlacement={'bottom'}
+          />
+          <div
+            className="user-name"
+            onClick={userChipHandler}
+          >
+            {userName}
+          </div>
         </div>
         }
       </header>

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -83,6 +83,7 @@
   "Header": {
     "nominatimPlaceHolder": "Ortsname, Straßenname, Stadtteilname, POI usw.",
     "helpButtonTooltip": "Hilfe",
+    "userChipButtonTooltip": "Login",
     "helpMessage": "Hilfe"
   },
   "LayerLegendAccordion": {

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -83,6 +83,7 @@
   "Header": {
     "nominatimPlaceHolder": "Municipality, street, district, poi…",
     "helpButtonTooltip": "Help",
+    "userChipButtonTooltip": "Login",
     "helpMessage": "Help"
   },
   "LayerLegendAccordion": {


### PR DESCRIPTION
## Description

This adds a user chip component to the header toolbar for e.g. login / logout functionality

![image](https://user-images.githubusercontent.com/1381363/144094171-a461c10b-d36f-4b19-93f4-b734af38ae3c.png)

@terrestris/devs please review

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
