### PR TITLE
Don't apply global text color for column sorter icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Don't apply global text color for column sorter icons ([#855](https://github.com/terrestris/react-geo-baseclient/pull/855))
 - Explicitly filter for ENABLE_LOADING and DISABLE_LOADING ([#854](https://github.com/terrestris/react-geo-baseclient/pull/854))
 - Fix check for a current hover/pointerrest on a non map element ([#853](https://github.com/terrestris/react-geo-baseclient/pull/853))
 - Added user chip to the header for login / logout

--- a/src/Main.css
+++ b/src/Main.css
@@ -13,7 +13,8 @@ body {
  */
 p, b, h1, h2, h3, h4, h5, em,
 div:not(.ant-tooltip-inner, .react-geo-measure-tooltip),
-span:not(.fa, .anticon.ant-alert-icon, .anticon.anticon-info-circle, .ant-notification-notice-icon),
+span:not(.fa, .anticon.ant-alert-icon, .anticon.anticon-info-circle,
+.ant-notification-notice-icon, .ant-table-column-sorter-down, .ant-table-column-sorter-up),
 a:not(.link),
 li {
   color: var(--textColor) !important;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Ensures the currently selected sort order will be highlighted in the sort icons.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
