### PR TITLE
Adds a versionnumber to the footer-element

### DIFF
--- a/src/component/container/Footer/Footer.css
+++ b/src/component/container/Footer/Footer.css
@@ -75,7 +75,7 @@
 
 @media only screen and (min-width: 500px) {
   .footer .imprint {
-    width: 100%;
+    width: 300px;
     justify-content: flex-end;
     padding-right: 10px;
   }
@@ -85,5 +85,21 @@
   .footer .imprint {
     width: 100%;
     justify-content: center;
+  }
+}
+
+.version_number {
+  display: flex;
+  flex-direction: row;
+  justify-content: right;
+  align-items: center;
+  padding-right: 100px;
+  width: 100%;
+  min-width: 250px;
+}
+
+@media only screen and (max-width: 1000px) {
+  .version_number {
+    display: none;
   }
 }

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -29,6 +29,7 @@ interface FooterProps extends Partial<DefaultFooterProps> {
   t: (arg: string) => {};
   mapScales: number[];
   projection: string;
+  version?: string;
 }
 
 interface FooterState {
@@ -199,6 +200,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
       mapScales,
       projection,
       imprint,
+      version,
       t
     } = this.props;
 
@@ -226,6 +228,9 @@ export class Footer extends React.Component<FooterProps, FooterState> {
         <div className="ol-mouse-position footer-element">
           <span>{t('MousePositionLabel')}: </span>
           <div id="mouse-position"/>
+        </div>
+        <div className="version_number">
+          <span>{t('Version')}: {version}</span>
         </div>
         <div className="imprint footer-element">
           {imprint ?

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -229,9 +229,9 @@ export class Footer extends React.Component<FooterProps, FooterState> {
           <span>{t('MousePositionLabel')}: </span>
           <div id="mouse-position"/>
         </div>
-        <div className="version_number">
-         {version && <span>{t('Version')}: {version}</span>}
-        </div>
+        {version && <div className="version_number">
+          <span>{t('Version')}: {version}</span>
+        </div>}
         <div className="imprint footer-element">
           {imprint ?
             <div dangerouslySetInnerHTML={{ __html: imprint }} /> :

--- a/src/component/container/Footer/Footer.tsx
+++ b/src/component/container/Footer/Footer.tsx
@@ -230,7 +230,7 @@ export class Footer extends React.Component<FooterProps, FooterState> {
           <div id="mouse-position"/>
         </div>
         <div className="version_number">
-          <span>{t('Version')}: {version}</span>
+         {version && <span>{t('Version')}: {version}</span>}
         </div>
         <div className="imprint footer-element">
           {imprint ?

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -167,5 +167,6 @@
   },
   "LayerTreeApplyTimeInterval": {
     "setTimeLineToLayerInterval": "Zeitraum des Layers anwenden"
-  }
+  },
+  "Version": "Versionsnummer"
 }

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -168,5 +168,5 @@
   "LayerTreeApplyTimeInterval": {
     "setTimeLineToLayerInterval": "Zeitraum des Layers anwenden"
   },
-  "Version": "Versionsnummer"
+  "Version": "Version"
 }

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -166,5 +166,6 @@
   },
   "LayerTreeApplyTimeInterval": {
     "setTimeLineToLayerInterval": "Apply time interval of the layer"
-  }
+  },
+  "Version": "Version"
 }


### PR DESCRIPTION
Implements the css, so that the element is shown in the application as wanted.

## Description

Adds a div within the footer, that displays the version-number and a string "version", that can be translated via the translate function.
The css let's the version-number disappear below a max-width of 1000px.  

## Related issues or pull requests

none

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes

- [x] No

## Checklist

- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).

![versionnumber](https://user-images.githubusercontent.com/100765498/158796187-c03fd2c1-dade-4f41-a838-2b8afbc6982b.gif)

