### PR TITLE
Reorganize CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow webpack proxy config through custom app config ([#841](https://github.com/terrestris/react-geo-baseclient/pull/841))
 - Update terrestris vectortiles lib ([#840](https://github.com/terrestris/react-geo-baseclient/pull/840))
 - Add tablet support for mobile device detection ([#848](https://github.com/terrestris/react-geo-baseclient/pull/848))
+- Reorganize CSS ([946](https://github.com/terrestris/react-geo-baseclient/pull/946))
 
 ## [2.0.1] - 2021-07-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,9 @@
         "i18next": "21.6.14",
         "i18next-browser-languagedetector": "6.1.3",
         "i18next-xhr-backend": "3.2.2",
-        "is-mobile": "^3.1.1",
+        "is-mobile": "3.1.1",
         "moment": "2.29.1",
+        "normalize.css": "^8.0.1",
         "object-fit-polyfill": "0.1.0",
         "ol": "6.13.0",
         "react": "17.0.2",
@@ -14982,6 +14983,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "node_modules/np": {
       "version": "7.6.0",
@@ -32726,6 +32732,11 @@
     "normalize-url": {
       "version": "6.1.0",
       "dev": true
+    },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "np": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "i18next-xhr-backend": "3.2.2",
     "is-mobile": "3.1.1",
     "moment": "2.29.1",
+    "normalize.css": "^8.0.1",
     "object-fit-polyfill": "0.1.0",
     "ol": "6.13.0",
     "react": "17.0.2",

--- a/src/Main.css
+++ b/src/Main.css
@@ -1,3 +1,8 @@
+html,
+html * {
+  box-sizing: border-box;
+}
+
 body {
   width: 100%;
   height: 100%;
@@ -5,58 +10,4 @@ body {
   padding: 0;
   font-family: sans-serif;
   overflow: hidden;
-}
-
-/**
- * Make most of the text elements use the defined text color.
- * This list may be incomplete
- */
-p, b, h1, h2, h3, h4, h5, em,
-div:not(.ant-tooltip-inner, .react-geo-measure-tooltip),
-span:not(.fa, .anticon.ant-alert-icon, .anticon.anticon-info-circle,
-.ant-notification-notice-icon, .ant-table-column-sorter-down, .ant-table-column-sorter-up),
-a:not(.link),
-li {
-  color: var(--textColor) !important;
-}
-
-/**
- * Brighten placeholder text
- */
-span.ant-select-selection-placeholder {
-  filter: opacity(0.5);
-}
-
-/**
- * Always underline the imprint text to indicate href
- */
-div.imprint.footer-element {
-  text-decoration: underline;
-}
-
-/**
- * Apply the baseColor to various elements
- */
-button, .ant-collapse-header, .react-geo-titlebar {
-  background-color: var(--baseColor) !important;
-}
-
-/**
- * Apply CSS filter brightness for hovered and pressed buttons
- */
-button:hover, .react-geo-togglebutton.btn-pressed {
-    filter: brightness(0.8);
-}
-
-@media only screen and (max-width: 768px) {
-  .react-geo-panel {
-      width: 100% !important;
-      transform: translate(0, 100px) !important;
-      min-width: unset !important;
-  }
-}
-
-.ant-tooltip .ant-tooltip-inner,
-.ant-tooltip .ant-tooltip-arrow-content {
-  background-color: rgba(0,0,0,.5);
 }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import 'normalize.css';
+import 'ol/ol.css';
 import './Theme.css';
 import './Main.css';
-import 'ol/ol.css';
 import SomethingWentWrong from './SomethingWentWrong';
 import { withTranslation } from 'react-i18next';
 import ProjectMain from './ProjectMain';

--- a/src/ProjectMain.css
+++ b/src/ProjectMain.css
@@ -37,3 +37,56 @@ header {
   bottom: 78px;
 }
 
+/**
+ * Apply the baseColor to various elements
+ */
+ button, .ant-collapse-header, .react-geo-titlebar {
+  background-color: var(--baseColor);
+}
+
+/**
+ * Make most of the text elements use the defined text color.
+ * This list may be incomplete
+ */
+ p, b, h1, h2, h3, h4, h5, em,
+ div:not(.ant-tooltip-inner, .react-geo-measure-tooltip),
+ span:not(.fa, .anticon.ant-alert-icon, .anticon.anticon-info-circle,
+ .ant-notification-notice-icon, .ant-table-column-sorter-down, .ant-table-column-sorter-up),
+ a:not(.link),
+ li {
+   color: var(--textColor);
+ }
+
+/**
+ * Brighten placeholder text
+ */
+span.ant-select-selection-placeholder {
+  filter: opacity(0.5);
+}
+
+/**
+ * Always underline the imprint text to indicate href
+ */
+div.imprint.footer-element {
+  text-decoration: underline;
+}
+
+/**
+ * Apply CSS filter brightness for hovered and pressed buttons
+ */
+button:hover, .react-geo-togglebutton.btn-pressed {
+    filter: brightness(0.8);
+}
+
+@media only screen and (max-width: 768px) {
+  .react-geo-panel {
+      width: 100%;
+      transform: translate(0, 100px);
+      min-width: unset;
+  }
+}
+
+.ant-tooltip .ant-tooltip-inner,
+.ant-tooltip .ant-tooltip-arrow-content {
+  background-color: rgba(0,0,0,.5);
+}


### PR DESCRIPTION
## Description

With this PR I propose to reorganize the CSS, because in the past it was often difficult to overwrite the definitions marked with `!important` in projects which use the _react-geo-baseclient_:

- Include the `normalize.css`.
- move all classes (especially those marked with `!important`) CSS into the stylesheet of the project to give new projects the greatest possible freedom in styling the components and remove `!important` keyword - in my opinion, no `!important` should be set by a basic library.

These changes **may** cause a breaking change in which the styles of some components are no longer defined within the base client. These must then be defined accordingly within the project.

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Other (please describe)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).

@terrestris/dev please review