### PR TITLE
LayerTreeClassic: Fix check for Legend component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 🚨 The `appContextLoading` state key has been removed.
   - 🚨 The state key `mapView` doesn't wrap its keys in `past`, `present` and `future` anymore.
   - 🚨 Removed actions `setLayers`, `addLayers`, `removeLayers`, `updateLayerOrder`, `changeLayerVisibility`.
+- `LayertreeClassic`: Added check for layer source type before adding the `Legend` component to a layer. https://github.com/terrestris/react-geo-baseclient/pull/1039
 
 ## [2.0.1] - 2021-07-21
 

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.tsx
@@ -24,6 +24,7 @@ import _isEmpty from 'lodash/isEmpty';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import ImageWMS from 'ol/source/ImageWMS';
+import { isWmsLayer } from '@terrestris/react-geo/dist/Util/typeUtils';
 
 interface DefaultLayerTreeClassicProps {
   extraLegendParams?: {};
@@ -52,7 +53,7 @@ export const LayerTreeClassic: React.FC<ComponentProps> = ({
     LEGEND_OPTIONS: 'fontAntiAliasing:true;forceLabels:on;fontName:DejaVu Sans Condensed',
     TRANSPARENT: true
   },
-  dispatch = () => {},
+  dispatch = () => { },
   showContextMenu,
   showApplyTimeInterval = false,
   showZoomToLayerExtent = false,
@@ -135,14 +136,16 @@ export const LayerTreeClassic: React.FC<ComponentProps> = ({
                   layer={layer}
                 />
               </div>
-              <Legend
-                layer={layer}
-                errorMsg={t('LayerTreeClassic.brokenLegendText')}
-                extraParams={{
-                  scale,
-                  ...extraLegendParams
-                }}
-              />
+              {isWmsLayer(layer) &&
+                <Legend
+                  layer={layer}
+                  errorMsg={t('LayerTreeClassic.brokenLegendText')}
+                  extraParams={{
+                    scale,
+                    ...extraLegendParams
+                  }}
+                />
+              }
             </>
           }
         </div>


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Adds check for layer source type `isWmsLayer` before adding the `Legend` component to a layer.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ x] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
