### PR TITLE
Add callback prop for gridIsReady event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add callback prop for gridIsReady event ([#1050](https://github.com/terrestris/react-geo-baseclient/pull/1050))
 - Add option to use filter on columns in featuregrid ([#1044](https://github.com/terrestris/react-geo-baseclient/pull/1044))
 - Added CORS Header to dev server config ([#1043](https://github.com/terrestris/react-geo-baseclient/pull/1043))
 - Configurable backend and client paths ([#861](https://github.com/terrestris/react-geo-baseclient/pull/861))

--- a/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
+++ b/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
@@ -34,6 +34,7 @@ interface FeatureInfoGridProps {
   onPaginationChange?: (idx: number) => void;
   t: (arg: any) => string;
   enableColumnFilter?: boolean;
+  onGridIsReadyCallback?: (arg: AgFeatureGridProps) => void;
 }
 
 interface ColumnDef {
@@ -68,7 +69,8 @@ export const FeatureInfoGrid: React.FC<ComponentProps> = ({
   map,
   onPaginationChange,
   t,
-  enableColumnFilter
+  enableColumnFilter,
+  onGridIsReadyCallback
 }): React.ReactElement => {
 
   const [selectedFeat, setSelectedFeat] = useState<OlFeature<OlGeomGeometry>>(features[0]);
@@ -330,6 +332,10 @@ export const FeatureInfoGrid: React.FC<ComponentProps> = ({
     updateSize(featureGrid);
 
     gridApi = featureGrid.api as GridApi;
+
+    if (onGridIsReadyCallback) {
+      onGridIsReadyCallback(featureGrid);
+    }
   };
 
   /**


### PR DESCRIPTION
## Description

Adds an optional callback prop for the "gridIsReady" event.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
