### PR TITLE
fix close button positioning

### DIFF
--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.css
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.css
@@ -1,3 +1,13 @@
+.layer-tree-classic {
+  position: absolute;
+  right: 2px;
+  z-index: 5;
+  background-color: #fffffff0;
+  border: 1px solid lightgray;
+  display: flex;
+  flex-direction: column;
+}
+
 .layer-tree-classic .react-geo-layertree {
   top: var(--header-height);
   width: var(--layerlegendaccordion-accordion-width);
@@ -5,18 +15,13 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  position: absolute;
-  right: 2px;
-  z-index: 5;
-  border: 1px solid lightgray;
-  background-color: #fffffff0;
 }
 
 .layer-tree-classic .ant-tree-title {
   font-size: 14px;
 }
 
-.layer-tree-classic .ant-tree-title .react-geo-legend > img {
+.layer-tree-classic .ant-tree-title .react-geo-legend>img {
   max-width: 90%;
 }
 
@@ -39,6 +44,7 @@
   display: flex;
   padding-top: 10px;
 }
+
 .layer-transparency .ant-slider {
   bottom: 5px;
   left: 5px;
@@ -54,10 +60,8 @@
 }
 
 .layer-tree-classic-close-button {
-  z-index: 10;
-  position: absolute;
-  right: 5px;
-  top: 52px;
+  align-self: flex-end;
+  margin: 5px;
 }
 
 .classic-tree-node-header {


### PR DESCRIPTION
## Description

Avoid overlapping of context menu icon of the topmost layer in layer tree by the close button. Non-functional change.


Before:

![image](https://user-images.githubusercontent.com/3939355/201330884-653cb28a-5977-474f-8e54-bfb2ec03d88b.png)


After:

![image](https://user-images.githubusercontent.com/3939355/201330959-35009d0c-472e-41b3-bc2b-84db96590379.png)

Please review @terrestris/devs 

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
