### PR TITLE
Downgrade openlayers to keep build working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Downgrade openlayers to keep build working ([#1061](https://github.com/terrestris/react-geo-baseclient/pull/1061))
 - Enhance typings of `PrintPanelV3` component ([#1052](https://github.com/terrestris/react-geo-baseclient/pull/1052))
 - Add callback prop for gridIsReady event ([#1050](https://github.com/terrestris/react-geo-baseclient/pull/1050))
 - Add option to use filter on columns in featuregrid ([#1044](https://github.com/terrestris/react-geo-baseclient/pull/1044))

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "antd": "4.18.9",
         "copy-to-clipboard": "3.3.2",
         "es-abstract": "^1.20.4",
-        "i18next": "^21.10.0",
+        "i18next": "21.10.0",
         "i18next-browser-languagedetector": "6.1.3",
         "i18next-xhr-backend": "3.2.2",
         "is-mobile": "3.1.1",
@@ -32,7 +32,7 @@
         "node-fetch": "^2.6.7",
         "normalize.css": "^8.0.1",
         "object-fit-polyfill": "0.1.0",
-        "ol": "6.15.1",
+        "ol": "6.14.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-i18next": "11.16.9",
@@ -17890,12 +17890,12 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.15.1.tgz",
-      "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.14.0.tgz",
+      "integrity": "sha512-pbbtK3tMza5DviljfxV+ZYMUEgCSo+ocZxsSBl4WAdy9k1g34PL2i1BpJ3BoUytiKxcQhglMgeWBceC3Ou4evg==",
       "dependencies": {
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "^8.0.5",
+        "geotiff": "^2.0.2",
+        "ol-mapbox-style": "^7.1.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -17905,12 +17905,13 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
-      "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
+      "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "mapbox-to-css-font": "^2.4.1",
+        "webfont-matcher": "^1.1.0"
       }
     },
     "node_modules/ol/node_modules/quickselect": {
@@ -38027,12 +38028,12 @@
       "dev": true
     },
     "ol": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.15.1.tgz",
-      "integrity": "sha512-ZG2CKTpJ8Q+tPywYysVwPk+yevwJzlbwjRKhoCvd7kLVWMbfBl1O/+Kg/yrZZrhG9FNXbFH4GeOZ5yVRqo3P4w==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.14.0.tgz",
+      "integrity": "sha512-pbbtK3tMza5DviljfxV+ZYMUEgCSo+ocZxsSBl4WAdy9k1g34PL2i1BpJ3BoUytiKxcQhglMgeWBceC3Ou4evg==",
       "requires": {
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "^8.0.5",
+        "geotiff": "^2.0.2",
+        "ol-mapbox-style": "^7.1.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -38053,12 +38054,13 @@
       }
     },
     "ol-mapbox-style": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.2.1.tgz",
-      "integrity": "sha512-3kBBuZC627vDL8vnUdfVbCbfkhkcZj2kXPHQcuLhC4JJEA+XkEVEtEde8x8+AZctRbHwBkSiubTPaRukgLxIRw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
+      "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
       "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "mapbox-to-css-font": "^2.4.1",
+        "webfont-matcher": "^1.1.0"
       }
     },
     "on-finished": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "node-fetch": "^2.6.7",
     "normalize.css": "^8.0.1",
     "object-fit-polyfill": "0.1.0",
-    "ol": "6.15.1",
+    "ol": "6.14.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-i18next": "11.16.9",


### PR DESCRIPTION
## Description

This downgrades openlayers to the last version that works together with inkmap.
When using the `PrintButton` from this repo in a project client, the build will fail with the following message:

`Module not found: Error: Can't resolve 'ol/source/State' in '.../react-geo-baseclient/node_modules/@camptocamp/inkmap/src/printer'`

This is because inkmap relies on older versions of ol which had those classes, but got removed / replaced in version 6.15.
I tried to fix the issue in inkmap itself, but failed due to lots of other appearing issues on ol-upgrade and limited time :-/

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
