### PR TITLE
Enable multiple FeatureInfoGrid downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Enable download of multiple `FeatureInfoGrids`
 - Downgrade openlayers to keep build working ([#1061](https://github.com/terrestris/react-geo-baseclient/pull/1061))
 - Enhance typings of `PrintPanelV3` component ([#1052](https://github.com/terrestris/react-geo-baseclient/pull/1052))
 - Add callback prop for gridIsReady event ([#1050](https://github.com/terrestris/react-geo-baseclient/pull/1050))

--- a/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
+++ b/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
@@ -12,7 +12,7 @@ import {
 } from 'antd';
 
 import AgFeatureGrid, { AgFeatureGridProps } from '@terrestris/react-geo/dist/Grid/AgFeatureGrid/AgFeatureGrid';
-import { GridApi, CsvExportModule } from 'ag-grid-community';
+import { GridApi, CsvExportModule, DetailGridInfo } from 'ag-grid-community';
 import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 import './FeatureInfoGrid.css';
@@ -284,7 +284,11 @@ export const FeatureInfoGrid: React.FC<ComponentProps> = ({
    */
   const downloadData = () => {
     if (Object.keys(gridApi).length) {
-      gridApi.exportDataAsCsv();
+      const detailedGrids: DetailGridInfo[] = [];
+      gridApi.forEachDetailGridInfo(grid => detailedGrids.push(grid));
+      if (detailedGrids.length) {
+        detailedGrids.forEach(grid => grid.api.exportDataAsCsv());
+      }
     }
   };
 
@@ -329,9 +333,20 @@ export const FeatureInfoGrid: React.FC<ComponentProps> = ({
    * Will be executed, when the grid is ready.
    */
   const onGridIsReady = (featureGrid: AgFeatureGridProps): void => {
+    const id = _uniqueId();
+    const gridInfo = {
+      id: id,
+      api: featureGrid.api,
+      columnApi: featureGrid.columnApi,
+    };
+
     updateSize(featureGrid);
 
-    gridApi = featureGrid.api as GridApi;
+    if (!gridApi) {
+      gridApi = featureGrid.api;
+    }
+
+    gridApi.addDetailGridInfo(id, gridInfo);
 
     if (onGridIsReadyCallback) {
       onGridIsReadyCallback(featureGrid);

--- a/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
+++ b/src/component/FeatureInfoGrid/FeatureInfoGrid.tsx
@@ -285,7 +285,7 @@ export const FeatureInfoGrid: React.FC<ComponentProps> = ({
   const downloadData = () => {
     if (Object.keys(gridApi).length) {
       const detailedGrids: DetailGridInfo[] = [];
-      gridApi.forEachDetailGridInfo(grid => detailedGrids.push(grid));
+      gridApi.forEachDetailGridInfo((grid: DetailGridInfo) => detailedGrids.push(grid));
       if (detailedGrids.length) {
         detailedGrids.forEach(grid => grid.api.exportDataAsCsv());
       }


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->
When using multiple `FeatureInfoGrids` in a component, the download would result in multiple `csv` with the same content. This should fix the issue.
credits: https://github.com/ag-grid/ag-grid/issues/2350

**Note:** When embedding multiple `FeatureInfoGrid` components in your component, only one should have `downloadGridData`, to avoid double downloads. Please check and comment if there is a more elegant way.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x] I have run the test suite successfully (run `npm test` locally).
