### PR TITLE
Fix mobile window

### DIFF
--- a/src/component/Menu/FeatureInfo/FeatureInfo.tsx
+++ b/src/component/Menu/FeatureInfo/FeatureInfo.tsx
@@ -24,7 +24,9 @@ import { MenuInfo } from 'rc-menu/lib/interface';
 import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 import Window from '@terrestris/react-geo/dist/Window/Window';
 
-const isEmpty = require('lodash/isEmpty');
+import isMobile from 'is-mobile';
+
+import _isEmpty from 'lodash/isEmpty';
 
 import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import FeatureInfoGrid from '../../FeatureInfoGrid/FeatureInfoGrid';
@@ -131,7 +133,7 @@ export const FeatureInfo: React.FC<ComponentProps> = ({
     const hoverVectorSource: OlSourceVector<OlGeometry> = hoverVectorLayer.getSource();
     clearHoverLayerSource();
     hoverVectorSource.addFeatures(hoverFeatures);
-    setMenuHidden(isEmpty(features));
+    setMenuHidden(_isEmpty(features));
   }, [features]);
 
   /**
@@ -318,7 +320,6 @@ export const FeatureInfo: React.FC<ComponentProps> = ({
     return tools;
   };
 
-
   let winTitle;
   let layerToShow;
 
@@ -327,6 +328,8 @@ export const FeatureInfo: React.FC<ComponentProps> = ({
     winTitle = layerToShow.get('name') || selectedFeatureType;
   }
 
+  const isMobileClient = isMobile({ tablet: true });
+
   return (
     <div>
       {
@@ -334,18 +337,18 @@ export const FeatureInfo: React.FC<ComponentProps> = ({
         <Window
           id={uniqueId('window-')}
           parentId={'app'}
-          resizeOpts={{}}
+          resizeOpts={true}
           draggable={true}
           collapsed={false}
           titleBarHeight={titleBarHeight}
           onEscape={hideFeatureInfoWindow}
           title={winTitle}
-          minWidth={500}
+          minWidth={isMobileClient? window.innerWidth : 500}
           maxWidth={1000}
-          width='auto'
+          width={isMobileClient ? window.innerWidth : 'auto'}
           height={windowHeight}
           maxHeight={1000}
-          x={windowPosition[0]}
+          x={isMobileClient ? 0 : windowPosition[0]}
           y={windowPosition[1]}
           collapseTooltip={t('General.collapse')}
           collapsible={windowCollapsible}

--- a/src/component/Permalink/Permalink.css
+++ b/src/component/Permalink/Permalink.css
@@ -8,7 +8,7 @@
 }
 
 .permalink input {
-  margin: 0 20px;
+  margin: 0 5px;
   flex: 1;
   border: solid 1px var(--baseColor);
   border-radius: 2px;

--- a/src/component/PrintPanel/PrintPanelV3.css
+++ b/src/component/PrintPanel/PrintPanelV3.css
@@ -97,10 +97,3 @@
 .print-panel span.react-geo-simplebutton {
   background-color: transparent;
 }
-
-@media only screen and (max-width: 768px) {
-  /* hide print preview for mobile clients */
-  .preview-card-col, .preview-button {
-    display: none !important;
-  }
-}

--- a/src/component/PrintPanel/PrintPanelV3.tsx
+++ b/src/component/PrintPanel/PrintPanelV3.tsx
@@ -28,6 +28,7 @@ import MapFishPrintV3Manager from '@terrestris/mapfish-print-manager/dist/manage
 
 import PrintUtil from '../../util/PrintUtil/PrintUtil';
 import { MapUtil } from '@terrestris/ol-util';
+import isMobile from 'is-mobile';
 
 import './PrintPanelV3.css';
 
@@ -646,7 +647,8 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
         >
           {/* preview column */}
           <Col
-            span={12}
+            xl={12}
+            xs={0}
             className={'preview-card-col'}
           >
             <Card className='preview-card'>
@@ -664,7 +666,8 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
           </Col>
           {/* settings column */}
           <Col
-            span={12}
+            xl={12}
+            xs={24}
           >
             {/* title and description */}
             <div className="wrapper-settings-col">
@@ -767,6 +770,7 @@ export class PrintPanelV3 extends React.Component<PrintPanelV3Props, PrintPanelV
             type="primary"
             loading={loadingPreview}
             disabled={printDisabled}
+            hidden={isMobile({ tablet: true })}
             onClick={() => this.onPrintBtnClick(true)}
           >
             {t('PrintPanel.previewCardTitle')}

--- a/src/component/button/PermalinkButton/PermalinkButton.tsx
+++ b/src/component/button/PermalinkButton/PermalinkButton.tsx
@@ -8,6 +8,8 @@ import { ButtonProps } from 'antd/lib/button';
 import { faLink, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import isMobile from 'is-mobile';
+
 import PermalinkUtil from '@terrestris/ol-util/dist/PermalinkUtil/PermalinkUtil';
 
 import OlMap from 'ol/Map';
@@ -46,6 +48,8 @@ export const PermalinkButton: React.FC<PermalinkButtonProps> = ({
 
   const [winVisible, setWinVisible] = useState(false);
 
+  const isMobileClient = isMobile({ tablet: true });
+
   return (
     <div>
       <SimpleButton
@@ -66,16 +70,16 @@ export const PermalinkButton: React.FC<PermalinkButtonProps> = ({
           id={uniqueId('window-')}
           parentId={'app'}
           resizeOpts={false}
-          collapsible={false}
+          collapsible={true}
           draggable={true}
           collapsed={false}
           titleBarHeight={37.5}
           onEscape={() => setWinVisible(!winVisible)}
           title={t('Permalink.windowTitle')}
-          width={750}
+          width={isMobileClient ? window.innerWidth : 750}
           height="auto"
           y={windowPosition && windowPosition[1] || 50}
-          x={windowPosition && windowPosition[0] || 100}
+          x={isMobileClient? 0 : windowPosition && windowPosition[0] || 100}
           enableResizing={false}
           collapseTooltip={t('General.collapse')}
           bounds="#app"

--- a/src/component/button/PrintButton/PrintButton.tsx
+++ b/src/component/button/PrintButton/PrintButton.tsx
@@ -4,6 +4,8 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
+import isMobile from 'is-mobile';
+
 import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 import Window from '@terrestris/react-geo/dist/Window/Window';
 
@@ -89,6 +91,8 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
       return <div />;
     }
 
+    const isMobileClient = isMobile({ tablet: true });
+
     return (
       <div>
         <SimpleButton
@@ -103,56 +107,57 @@ export default class PrintButton extends React.Component<PrintButtonProps, Print
           tooltipPlacement={tooltipPlacement}
           onClick={this.changeFullPrintWindowVisibility}
         />
-        { winVisible &&
-        <Window
-          id={uniqueId('window-')}
-          parentId={'app'}
-          resizeOpts={false}
-          collapsible={false}
-          draggable={true}
-          collapsed={false}
-          titleBarHeight={37.5}
-          onEscape={this.changeFullPrintWindowVisibility}
-          title={t('PrintPanel.windowTitle')}
-          width={750}
-          height="auto"
-          y={50}
-          x={100}
-          enableResizing={false}
-          collapseTooltip={t('General.collapse')}
-          bounds="#app"
-          tools={[
-            <SimpleButton
-              icon={
-                <FontAwesomeIcon
-                  icon={faTimes}
-                />
-              }
-              key="close-tool"
-              size="small"
-              tooltip={t('General.close')}
-              onClick={this.changeFullPrintWindowVisibility}
+        {
+          winVisible &&
+          <Window
+            id={uniqueId('window-')}
+            parentId={'app'}
+            resizeOpts={false}
+            collapsible={true}
+            draggable={true}
+            collapsed={false}
+            titleBarHeight={37.5}
+            onEscape={this.changeFullPrintWindowVisibility}
+            title={t('PrintPanel.windowTitle')}
+            width={isMobileClient ? window.innerWidth: 750}
+            height="auto"
+            y={50}
+            x={isMobileClient ? 0 : 100}
+            enableResizing={false}
+            collapseTooltip={t('General.collapse')}
+            bounds="#app"
+            tools={[
+              <SimpleButton
+                icon={
+                  <FontAwesomeIcon
+                    icon={faTimes}
+                  />
+                }
+                key="close-tool"
+                size="small"
+                tooltip={t('General.close')}
+                onClick={this.changeFullPrintWindowVisibility}
+              />
+            ]}
+          >
+            <PrintPanelV3
+              map={map}
+              key="5"
+              t={t}
+              config={config}
+              printTitle={printTitle}
+              legendBlackList={[
+                'react-geo_measure',
+                'hoverVectorLayer'
+              ]}
+              printLayerBlackList={[
+                'react-geo_measure',
+                'hoverVectorLayer',
+                'react-geo_geolocationlayer'
+              ]}
+              printScales={printScales}
             />
-          ]}
-        >
-          <PrintPanelV3
-            map={map}
-            key="5"
-            t={t}
-            config={config}
-            printTitle={printTitle}
-            legendBlackList={[
-              'react-geo_measure',
-              'hoverVectorLayer'
-            ]}
-            printLayerBlackList={[
-              'react-geo_measure',
-              'hoverVectorLayer',
-              'react-geo_geolocationlayer'
-            ]}
-            printScales={printScales}
-          />
-        </Window>
+          </Window>
         }
       </div>
     );

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.css
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.css
@@ -13,7 +13,6 @@
 
 .layer-tree-classic .react-geo-layertree {
   top: var(--header-height);
-  width: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -36,6 +35,12 @@
   }
   .layer-tree-classic .ant-tree-title {
     font-size: 20px;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .layer-tree-classic {
+    min-width: 400px;
   }
 }
 
@@ -81,7 +86,7 @@
   margin-left: 5px;
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 769px) {
   .layer-tree-classic-close-button {
     display: none;
   }

--- a/src/component/container/LayerTreeClassic/LayerTreeClassic.css
+++ b/src/component/container/LayerTreeClassic/LayerTreeClassic.css
@@ -1,18 +1,19 @@
 .layer-tree-classic {
   position: absolute;
-  right: 2px;
+  right: 0px;
   z-index: 5;
   background-color: #fffffff0;
   border: 1px solid lightgray;
   display: flex;
   flex-direction: column;
+  max-height: calc(100% - var(--header-height) - var(--footer-height));
+  overflow-y: auto;
 }
+
 
 .layer-tree-classic .react-geo-layertree {
   top: var(--header-height);
-  width: var(--layerlegendaccordion-accordion-width);
-  max-height: calc(100% - var(--header-height) - var(--footer-height));
-  overflow-y: auto;
+  width: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -30,6 +31,9 @@
 }
 
 @media only screen and (max-width: 768px) {
+  .layer-tree-classic {
+    width: 100%;
+  }
   .layer-tree-classic .ant-tree-title {
     font-size: 20px;
   }


### PR DESCRIPTION
## Description
* Prevent mobile windows to overflow the viewport dimensions, always fit to 100% mobile viewport width
  * Fixes mobile view for print, permalink and featureinfo grid panels
* Hide preview column on print panel in mobile
* Avoid cropped button in permalink dialog
* Restores scrollbar of layer tree and fix padding to avoid cropped collapse icons.

Please review @terrestris/devs 

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [ ] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
