### PR TITLE
fix: layerfilter now correctly detects source type again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- fix: layerfilter now correctly detects source type again ([#1083](https://github.com/terrestris/react-geo-baseclient/pull/1083))
+
 ## 4.0.0 - 2022-12-14
 
 Breaking:

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@reduxjs/toolkit": "^1.9.0",
     "@terrestris/base-util": "1.0.1",
     "@terrestris/mapfish-print-manager": "^7.0.2",
-    "@terrestris/ol-util": "^10.1.2",
+    "@terrestris/ol-util": "^10.1.3",
     "@terrestris/react-geo": "^22.0.0",
     "@terrestris/vectortiles": "0.4.0",
     "antd": "4.18.9",

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -151,7 +151,8 @@ export const HsiButton: React.FC<ComponentProps> = ({
       }
       const coordinate: number[] = map.getCoordinateFromPixel(pixel);
 
-      if (layer.getSource().constructor.name === 'VectorSource') {
+      // @ts-ignore
+      if (layer.getSource().getFeatures) {
         internalVectorFeatures[layer.get('name')] = [];
         const internalFeatures = olEvt.map.getFeaturesAtPixel(pixel, {
           layerFilter: (layerCandidate: LayerType) => {
@@ -227,10 +228,18 @@ export const HsiButton: React.FC<ComponentProps> = ({
  * @return {Boolean} Whether the layer is hoverable or not.
  */
   const layerFilter = (layerCandidate: LayerType) => {
-    const source = layerCandidate.getSource();
+    interface UnknownOlSource {
+      getImageLoadFunction?: any;
+      getTileGrid?: any;
+      getFeatures?: any;
+      getMatrixSet?: any;
+    }
+    const source = layerCandidate.getSource() as UnknownOlSource;
     const isHoverable: boolean = layerCandidate.get('hoverable');
-    const isSupportedHoverSource: boolean = source.constructor.name === 'ImageWMS' ||
-      source.constructor.name === 'TileWMS' || source.constructor.name === 'VectorSource';
+    const isSupportedHoverSource: boolean =
+      source.getImageLoadFunction || // 'ImageWMS'
+      source.getTileGrid && !source.getMatrixSet || // 'TileWMS'
+      source.getFeatures; // 'VectorSource'
     return isHoverable && isSupportedHoverSource;
   };
 


### PR DESCRIPTION
## Description

Fixes the determination of layer sources by checking for specific functions, as production builds obfuscate the constructor names

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [x ] I have run the test suite successfully (run `npm test` locally).
