### PR TITLE
fix: add check to hover only visible layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- fix: add check to hover only visible layers ([#1084](https://github.com/terrestris/react-geo-baseclient/pull/1084))
 - fix: layerfilter now correctly detects source type again ([#1083](https://github.com/terrestris/react-geo-baseclient/pull/1083))
 
 ## 4.0.0 - 2022-12-14

--- a/src/component/button/HsiButton/HsiButton.tsx
+++ b/src/component/button/HsiButton/HsiButton.tsx
@@ -236,11 +236,12 @@ export const HsiButton: React.FC<ComponentProps> = ({
     }
     const source = layerCandidate.getSource() as UnknownOlSource;
     const isHoverable: boolean = layerCandidate.get('hoverable');
+    const isVisible: boolean = layerCandidate.getVisible();
     const isSupportedHoverSource: boolean =
       source.getImageLoadFunction || // 'ImageWMS'
       source.getTileGrid && !source.getMatrixSet || // 'TileWMS'
       source.getFeatures; // 'VectorSource'
-    return isHoverable && isSupportedHoverSource;
+    return isHoverable && isVisible && isSupportedHoverSource;
   };
 
   return (


### PR DESCRIPTION
## Description

This way, only currently visible layers will be hovered.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
- [x] I have added the proposed change to the `CHANGELOG.md`.
- [ ] I have run the test suite successfully (run `npm test` locally).
